### PR TITLE
Changed setup.sh to prompt user for the password to the root account …

### DIFF
--- a/db_setup/setup.sh
+++ b/db_setup/setup.sh
@@ -68,8 +68,10 @@ read -p "Are you sure? " -n 1 -r
 echo    # (optional) move to a new line
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
+	echo -n 'Password for orientdb root account:'
+	read -s PASSWORD
 #	(cd ${ORIENTDB_HOME}/bin && source console.sh $STIG_DIR/empty_build_db.txt)
-	(cd ${ORIENTDB_HOME}/bin && source console.sh "SET ignoreErrors true;DROP DATABASE remote:localhost/stig root admin plocal;SET ignoreErrors false;CREATE DATABASE remote:localhost/stig root admin plocal;IMPORT DATABASE $STIG_DIR/stig.gz -preserveClusterIDs=true")
+	(cd ${ORIENTDB_HOME}/bin && source console.sh "SET ignoreErrors true;DROP DATABASE remote:localhost/stig root $PASSWORD plocal;SET ignoreErrors false;CREATE DATABASE remote:localhost/stig root $PASSWORD plocal;IMPORT DATABASE $STIG_DIR/stig.gz -preserveClusterIDs=true")
 
 fi
 


### PR DESCRIPTION
…in orientDB. Previously it had relied on a default password of root/admin. This causes errors if the user failed to set the password to admin when installing orientDB. 

This should provide more flexibility and a touch more security. 