### PR TITLE
Change authored_by schema to hyphen #66

### DIFF
--- a/src/static/jsedit/relationship.json
+++ b/src/static/jsedit/relationship.json
@@ -53,7 +53,7 @@
                 "affected-by",
                 "compromised-by",
                 "based-on",
-                "authored_by",
+                "authored-by",
                 "communicates-with",
                 "exfiltrates-to",
                 "beacons-to",


### PR DESCRIPTION
Changing "authored_by" to "authored-by" so schema of this type added in STIG validate as STIX, as in #66