### PR TITLE
Fix authored_by schema typo #66

### DIFF
--- a/db_setup/stix_loader/models/v21/stixmodels.py
+++ b/db_setup/stix_loader/models/v21/stixmodels.py
@@ -572,7 +572,7 @@ class AnalysisOf(Relationships):
 
 
 class AuthoredBy(Relationships):
-    label = 'authored_by'
+    label = 'authored-by'
     created = DateTime(nullable=False)
     modified = DateTime(nullable=False)
     external_references = EmbeddedList()


### PR DESCRIPTION
Changing "authored_by" to "authored-by" so schema of this type added in STIG validate as STIX, as in #66