### PR TITLE
Fix third authored_by schema typo #66

### DIFF
--- a/src/static/jsedit/malware-relationship.json
+++ b/src/static/jsedit/malware-relationship.json
@@ -34,7 +34,7 @@
                 "beacons-to",
                 "originates-from",
                 "variant-of",
-                "authored_by",
+                "authored-by",
                 "related-to",
                 "created-by",
                 "derived-from",


### PR DESCRIPTION
Changing "authored_by" to "authored-by" so schema of this type added in STIG validate as STIX, as in #66