### PR TITLE
linux/amd64: fix unhandled promise at app startup without db conneciton

### DIFF
--- a/src/db/db.ts
+++ b/src/db/db.ts
@@ -107,7 +107,7 @@ export class StigDB {
     constructor(dbname: string) {
         ipcRenderer.on('database_reconfigured', (_event: Event, options: IDatabaseConfigOptions) => this.changeConfig(options));
         this.diff_dialog = new DiffDialog($('#diff-anchor'));
-        if (dbname === undefined) {
+        if (this.dbname === undefined) {
             this.configure();
         } else {
             this.changeConfig(DatabaseConfigurationStorage.Instance.get(dbname));


### PR DESCRIPTION
When the app is installed via .deb an unhandled promise occurs at startup, if there is no database connection, instead of opening the create db connection prompt. 

```
Unhandled Promise Rejection
TypeError: Cannot read property 'username' of undefined
    at StigDB.changeConfig (/usr/lib/stig/resources/app/src/db/db.ts:115:64)
    at new StigDB (/usr/lib/stig/resources/app/src/db/db.ts:98:18)
    at HTMLDocument.document.addEventListener (/usr/lib/stig/resources/app/src/main.ts:64:24)

```

The issue appears to come from checking the wrong property in the StigDB constructor. 