### PR TITLE
Object literal evaluates to wrong type

### DIFF
--- a/src/storage/database-configuration-storage.ts
+++ b/src/storage/database-configuration-storage.ts
@@ -50,7 +50,10 @@ export class DatabaseConfigurationStorage {
             password: 'admin',
             usetoken: true,
         };
-        this.store.set('configs', {stig: initial});
+        const configmap: IDatabaseConfigMap = {
+            [initial.name]: initial,
+        };
+        this.store.set('configs', configmap);
         this.current = 'stig';
     }
 


### PR DESCRIPTION
`IDatabaseConfigurationStorageStructure.configs` is type `IDatabaseConfigMap`, but the used object literal evaluates to `IDatabaseConfigOptions`. This fix declares a new property `configmap` of type `IDatabaseConfigMap`  which is passed to the ElectronStore set function.