### PR TITLE
Updates to readthedocs Instance

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
+
+# We recommend specifying your dependencies to enable reproducible builds:
+# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#   install:
+#   - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,9 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+  jobs:
+    post_create_environment:
+      - python -m pip install sphinx_rtd_theme
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,7 @@
 # import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
-import sphinx_rtd_theme
+# import sphinx_rtd_theme
 
 
 # -- Project information -----------------------------------------------------


### PR DESCRIPTION
This PR updates the project's readthedocs instance (https://stig.readthedocs.io/en/latest/) to render the changes that have been put into the docs folder in the last ~2 years. The main update to the documentation site is removal of OrientDB documentation and addition of Neo4j documentation to resolve #125.

The documentation that will get pushed to the readthedocs link above for our latest docs version when this gets merged can be previewed here: https://stig.readthedocs.io/en/deprecated_readthedocs_fix/.