### PR TITLE
Update running and schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ out
 **/*.bak
 **/*.swp
 src/static/index.js
+neo4jdata/*

--- a/Dockerfile_insecure
+++ b/Dockerfile_insecure
@@ -6,13 +6,12 @@ RUN mkdir /stig
 # This is likely excessive, we may wish to slim down the needed files at some point
 WORKDIR /stig
 COPY assets assets
-COPY db_setup db_setup
 COPY images images
 COPY src src
 COPY *.ts ./
 COPY *.json ./
 COPY *.js ./
-COPY *.lock ./
+COPY package* ./
 RUN npm config set strict-ssl false
 RUN npm install --quiet
 CMD ["npm", "start"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "stig",
-    "version": "2.0.1",
+    "version": "2.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "stig",
-            "version": "2.0.1",
+            "version": "2.2.0",
             "license": "SEE LICENSE IN LICENSE.txt",
             "dependencies": {
                 "@json-editor/json-editor": "^2.15.0",

--- a/package.json
+++ b/package.json
@@ -3,13 +3,16 @@
     "productName": "STIG",
     "title": "STIG",
     "description": "A tool for creating, managing, visualizing and querying structured threat intelligence.",
-    "version": "2.0.1",
+    "version": "2.2.0",
     "main": "src/index.ts",
     "author": {
         "name": "Jed Haile",
         "email": "jed.haile@inl.gov"
     },
     "contributors": [
+        "Adeline Reichart",
+        "Logan Kearsley", 
+        "Will Brant",
         "Justin Cox",
         "Greer Galloway",
         "Michael Madsen",

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -261,11 +261,7 @@ export const schema: ISchemaFile = {
       properties: [
         { name: 'name', type: 'String', mandatory: true, notNull: true, collate: 'default' },
         { name: 'description', type: 'String', collate: 'default' },
-        { name: 'action', type: 'String' }, // This is no longer in spec
-        { name: 'action_type', type: 'String', collate: 'default' }, // How can we enforce open-vocab by SDO/SCO
-        { name: 'os_execution_envs', type: 'EmbeddedList', collate: 'default' },
-        { name: 'action_bin', type: 'Binary', collate: 'default' },
-        { name: 'action_reference', type: 'String', collate: 'default' }// How can we enforce certain rules and create custom TYPES for orientdb
+        { name: 'action', type: 'String' }, //ATTN: This is reserved, but not currently implemented in the spec
       ]
     },
     {
@@ -359,6 +355,7 @@ export const schema: ISchemaFile = {
       superClasses: ['core'],
       properties: [
         { name: 'name', type: 'String', collate: 'default' },
+        { name: 'description', type: 'String', collate: 'default' },
         { name: 'schema', type: 'String', mandatory: true, notNull: true, collate: 'default' },
         { name: 'version', type: 'String', mandatory: true, notNull: true, collate: 'default' },
         { name: 'extension_types', type: 'EmbeddedList', mandatory: true, notNull: true, collate: 'default' },
@@ -412,8 +409,8 @@ export const schema: ISchemaFile = {
         { name: 'name', type: 'String', mandatory: true, notNull: true, collate: 'default' },
         { name: 'description', type: 'String', collate: 'default' },
         { name: 'roles', type: 'EmbeddedList', collate: 'default' },
-        { name: 'identity_class', type: 'String', mandatory: true, notNull: true, collate: 'default' },
-        { name: 'sectors', type: 'EmbeddedList', collate: 'default' },
+        { name: 'identity_class', type: 'String', collate: 'default' },
+        { name: 'sectors', type: 'EmbeddedList', collate: 'default' }, //TODO: enforce open-vocab industry-sector-ov
         { name: 'contact_information', type: 'String', collate: 'default' }
       ]
     },
@@ -450,7 +447,7 @@ export const schema: ISchemaFile = {
       properties: [
         { name: 'name', type: 'String', mandatory: true, notNull: true, collate: 'default' },
         { name: 'description', type: 'String', collate: 'default' },
-        { name: 'infrastructure_types', type: 'EmbeddedList', notNull: true, collate: 'default' },
+        { name: 'infrastructure_types', type: 'EmbeddedList', collate: 'default' },
         { name: 'aliases', type: 'EmbeddedList', collate: 'default' },
         { name: 'kill_chain_phases', type: 'EmbeddedList', collate: 'default' },
         { name: 'first_seen', type: 'DateTime', collate: 'default' },
@@ -535,7 +532,7 @@ export const schema: ISchemaFile = {
       properties: [
         { name: 'name', type: 'String', collate: 'default' },
         { name: 'description', type: 'String', collate: 'default' },
-        { name: 'malware_types', type: 'EmbeddedList', notNull: true, mandatory: true, collate: 'default' },
+        { name: 'malware_types', type: 'EmbeddedList', collate: 'default' },
         { name: 'is_family', type: 'Boolean', notNull: true, mandatory: true, collate: 'default' },
         { name: 'aliases', type: 'EmbeddedList', collate: 'default' },
         { name: 'kill_chain_phases', type: 'EmbeddedList', collate: 'default' },
@@ -565,10 +562,10 @@ export const schema: ISchemaFile = {
         { name: 'analysis_started', type: 'DateTime', collate: 'default' },
         { name: 'analysis_ended', type: 'DateTime', collate: 'default' },
         { name: 'av_result', type: 'String', collate: 'default' },
-        // {name: "result_name", type: "String", collate: "default"},
-        // {name: "result", type: "String", collate: "default"},
-        { name: 'analysis_sco_refs', type: 'EmbeddedList', collate: 'default' }
-        // {name: "sample_ref", type: "String", collate: "default"},
+        {name: "result_name", type: "String", collate: "default"},
+        {name: "result", type: "String", collate: "default"}, //TODO: enforce open-vocab malware-result-ov
+        { name: 'analysis_sco_refs', type: 'EmbeddedList', collate: 'default' },
+        {name: "sample_ref", type: "String", collate: "default"},
       ]
     },
     {
@@ -576,8 +573,8 @@ export const schema: ISchemaFile = {
       superClasses: ['markingmetacore'],
       properties: [
         { name: 'name', type: 'String', collate: 'default' },
-        { name: 'definition_type', type: 'String', mandatory: true, notNull: true, collate: 'default' },
-        { name: 'definition', type: 'EmbeddedMap', mandatory: true, notNull: true, collate: 'default' }
+        { name: 'definition_type', type: 'String', collate: 'default' },
+        { name: 'definition', type: 'EmbeddedMap', collate: 'default' }
       ]
     },
     {
@@ -642,7 +639,7 @@ export const schema: ISchemaFile = {
       properties: [
         { name: 'explanation', type: 'String', collate: 'default' },
         { name: 'authors', type: 'EmbeddedList', collate: 'default' },
-        { name: 'opinion', type: 'String', mandatory: true, notNull: true, collate: 'default' }, // enum
+        { name: 'opinion', type: 'String', mandatory: true, notNull: true, collate: 'default' }, // TODO: enforce opinion-enum
         { name: 'object_refs', type: 'EmbeddedList', mandatory: true, notNull: true, collate: 'default' }
       ]
     },
@@ -688,7 +685,7 @@ export const schema: ISchemaFile = {
       properties: [
         { name: 'name', type: 'String', mandatory: true, notNull: true, collate: 'default' },
         { name: 'description', type: 'String', collate: 'default' },
-        { name: 'report_types', type: 'EmbeddedList', notNull: true, collate: 'default' },
+        { name: 'report_types', type: 'EmbeddedList', collate: 'default' }, //TODO: enforce report-type-ov
         { name: 'published', type: 'DateTime', mandatory: true, notNull: true, collate: 'default' },
         { name: 'object_refs', type: 'EmbeddedList', mandatory: true, notNull: true, collate: 'default' }
       ]
@@ -722,7 +719,7 @@ export const schema: ISchemaFile = {
       properties: [
         { name: 'name', type: 'String', mandatory: true, notNull: true, collate: 'default' },
         { name: 'description', type: 'String', collate: 'default' },
-        { name: 'threat_actor_types', type: 'EmbeddedList', mandatory: true, notNull: true, collate: 'default' },
+        { name: 'threat_actor_types', type: 'EmbeddedList', collate: 'default' },
         { name: 'aliases', type: 'EmbeddedList', collate: 'default' },
         { name: 'first_seen', type: 'DateTime', collate: 'default' },
         { name: 'last_seen', type: 'DateTime', collate: 'default' },
@@ -741,7 +738,7 @@ export const schema: ISchemaFile = {
       properties: [
         { name: 'name', type: 'String', mandatory: true, notNull: true, collate: 'default' },
         { name: 'description', type: 'String', collate: 'default' },
-        { name: 'tool_types', type: 'EmbeddedList', mandatory: true, notNull: true, collate: 'default' },
+        { name: 'tool_types', type: 'EmbeddedList', collate: 'default' }, //TODO: enforce tool-type-ov
         { name: 'aliases', type: 'EmbeddedList', collate: 'default' },
         { name: 'kill_chain_phases', type: 'EmbeddedList', collate: 'default' },
         { name: 'tool_version', type: 'String', collate: 'default' }
@@ -791,7 +788,8 @@ export const schema: ISchemaFile = {
       superClasses: ['core'],
       properties: [
         { name: 'name', type: 'String', mandatory: true, notNull: true, collate: 'default' },
-        { name: 'description', type: 'String', collate: 'default' }
+        { name: 'description', type: 'String', collate: 'default' },
+        { name: 'external_references', type: 'EmbeddedList', collate: 'default'} //list of external-reference
       ]
     },
     {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -410,7 +410,7 @@ export const schema: ISchemaFile = {
         { name: 'description', type: 'String', collate: 'default' },
         { name: 'roles', type: 'EmbeddedList', collate: 'default' },
         { name: 'identity_class', type: 'String', collate: 'default' },
-        { name: 'sectors', type: 'EmbeddedList', collate: 'default' }, //TODO: enforce open-vocab industry-sector-ov
+        { name: 'sectors', type: 'EmbeddedList', collate: 'default' }, 
         { name: 'contact_information', type: 'String', collate: 'default' }
       ]
     },
@@ -434,7 +434,7 @@ export const schema: ISchemaFile = {
         { name: 'description', type: 'String', collate: 'default' },
         { name: 'indicator_types', type: 'EmbeddedList', notNull: true, collate: 'default' },
         { name: 'pattern', type: 'String', mandatory: true, notNull: true, collate: 'default' },
-        { name: 'pattern_type', type: 'String', mandatory: true, notNull: true, collate: 'default' },
+        { name: 'pattern_type', type: 'String', notNull: true, collate: 'default' },
         { name: 'pattern_version', type: 'String', collate: 'default' },
         { name: 'valid_from', type: 'DateTime', mandatory: true, notNull: true, collate: 'default' },
         { name: 'valid_until', type: 'DateTime', collate: 'default' },

--- a/src/main.ts
+++ b/src/main.ts
@@ -675,18 +675,26 @@ export class Main {
         // Get raw data from all cy elements
         // Create bundle object
         const bundle_id = 'bundle--' + uuid.v4();
-        const bundle: BundleType = { type: 'bundle', id: bundle_id, objects: [] } as any;
+        let bundle: BundleType = { type: 'bundle', id: bundle_id, objects: [] } as any;
         let nodes = window.cycore.$(':visible');
         nodes = nodes.union(nodes.connectedEdges());
+        
+        //ATTN: the following logic may actually do nothing at all. If that is the case, this problem can be solved by doing the filter like on the visual edges
+        // logic to remove null on json export
         nodes.each((ele) => {
           if (ele.length === 0) {
             return;
           }
-          // logic to remove null on json export
           if (ele.data('raw_data') !== undefined) {
             bundle.objects.push(ele.data('raw_data'));
           }
         });
+
+        //filter out embedded relationship visual edges
+        bundle.objects = bundle.objects.filter((bundleObj: any) => {
+          return bundleObj !== "visual_edge";
+        })
+
         // Open the export widget
         openBundleExport(bundle);
       });

--- a/src/static/jsedit/attack-pattern.json
+++ b/src/static/jsedit/attack-pattern.json
@@ -1,46 +1,53 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "Attack Pattern",
-    "$ref": "static/jsedit/core.json",
-    "type": "object",
-    "description": "Attack Patterns are a type of TTP that describe ways that adversaries attempt to compromise targets.",
-    "properties": {
-        "id": {
-            "type": "string",
-            "default": "attack-pattern--",
-            "pattern": "^[a-z][a-z-]+[a-z]--[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
-            "readonly": "true"
-        },
+  "$id": "http://raw.githubusercontent.com/oasis-open/cti-stix2-json-schemas/stix2.1/schemas/sdos/attack-pattern.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "attack-pattern",
+  "description": "Attack Patterns are a type of TTP that describe ways that adversaries attempt to compromise targets. ",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "static/jsedit/core.json"
+    },
+    {
+      "properties": {
         "type": {
-            "type": "string",
-            "default": "attack-pattern",
-            "readonly": "true"
+          "type": "string",
+          "description": "The type of this object, which MUST be the literal `attack-pattern`.",
+          "enum": [
+            "attack-pattern"
+          ]
+        },
+        "aliases" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          },
+          "description": "Alternative names used to identify this Attack Pattern."
+        },
+        "id": {
+          "title": "id",
+          "pattern": "^attack-pattern--"
         },
         "name": {
-            "type": "string",
-            "description": "The name used to identify the Attack Pattern."
+          "type": "string",
+          "description": "The name used to identify the Attack Pattern."
         },
         "description": {
-            "type": "string",
-            "format": "textarea",
-            "description": "A description that provides more details and context about the Attack Pattern, potentially including its purpose and its key characteristics."
-        },
-        "aliases": {
-            "type": "array",
-            "description": "Alternative names used to identify this mattack pattern.",
-            "items": {
-                "type": "string"
-            },
-            "minItems": 1
+          "type": "string",
+          "description": "A description that provides more details and context about the Attack Pattern, potentially including its purpose and its key characteristics."
         },
         "kill_chain_phases": {
-            "type": "array",
-            "description": "The list of kill chain phases for which this attack pattern is used.",
-            "$ref": "static/jsedit/kill-chain-phase.json",
-            "minItems": 1
+          "type": "array",
+          "description": "The list of kill chain phases for which this attack pattern is used.",
+          "items": {
+            "$ref": "static/jsedit/common/kill-chain-phase.json"
+          },
+          "minItems": 1
         }
-    },
-    "required": [
-        "name"
-    ]
+      }
+    }
+  ],
+  "required": [
+    "name"
+  ]
 }

--- a/src/static/jsedit/campaign.json
+++ b/src/static/jsedit/campaign.json
@@ -38,10 +38,12 @@
           "minItems": 1
         },
         "first_seen": {
+          "title":"first_seen",
           "$ref": "static/jsedit/common/timestamp.json",
           "description": "The time that this Campaign was first seen."
         },
         "last_seen": {
+          "title":"last_seen",
           "$ref": "static/jsedit/common/timestamp.json",
           "description": "The time that this Campaign was last seen."
         },

--- a/src/static/jsedit/campaign.json
+++ b/src/static/jsedit/campaign.json
@@ -1,54 +1,58 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "Campaign",
-    "description": "A Campaign is a grouping of adversary behavior that describes a set of malicious activities or attacks that occur over a period of time against a specific set of targets.",
-    "$ref": "static/jsedit/core.json",
-    "properties": {
-        "id": {
-            "type": "string",
-            "pattern": "^campaign--",
-            "default": "campaign--",
-            "readonly": "true"
-        },
+  "$id": "http://raw.githubusercontent.com/oasis-open/cti-stix2-json-schemas/stix2.1/schemas/sdos/campaign.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "campaign",
+  "description": "A Campaign is a grouping of adversary behavior that describes a set of malicious activities or attacks that occur over a period of time against a specific set of targets.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "static/jsedit/core.json"
+    },
+    {
+      "properties": {
         "type": {
-            "type": "string",
-            "description": "The type of this object, which MUST be the literal `campaign`.",
-            "default": "campaign",
-            "readonly": "true"
+          "type": "string",
+          "description": "The type of this object, which MUST be the literal `campaign`.",
+          "enum": [
+            "campaign"
+          ]
+        },
+        "id": {
+          "title": "id",
+          "pattern": "^campaign--"
         },
         "name": {
-            "type": "string",
-            "description": "The name used to identify the Campaign."
+          "type": "string",
+          "description": "The name used to identify the Campaign."
         },
         "description": {
-            "type": "string",
-            "format": "textarea",
-            "description": "A description that provides more details and context about the Campaign, potentially including its purpose and its key characteristics."
+          "type": "string",
+          "description": "A description that provides more details and context about the Campaign, potentially including its purpose and its key characteristics."
         },
         "aliases": {
-            "type": "array",
-            "description": "Alternative names used to identify this campaign.",
-            "items": {
-                "type": "string"
-            },
-            "minItems": 1
+          "type": "array",
+          "description": "Alternative names used to identify this campaign.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
         },
         "first_seen": {
-            "type": "string",
-            "format": "datetime",
-            "description": "The time that this Campaign was first seen."
+          "$ref": "static/jsedit/common/timestamp.json",
+          "description": "The time that this Campaign was first seen."
         },
         "last_seen": {
-            "type": "string",
-            "format": "datetime",
-            "description": "The time that this Campaign was last seen."
+          "$ref": "static/jsedit/common/timestamp.json",
+          "description": "The time that this Campaign was last seen."
         },
         "objective": {
-            "type": "string",
-            "description": "This field defines the Campaign’s primary goal, objective, desired outcome, or intended effect."
+          "type": "string",
+          "description": "This field defines the Campaign’s primary goal, objective, desired outcome, or intended effect."
         }
-    },
-    "required": [
-        "name"
-    ]
+      }
+    }
+  ],
+  "required": [
+    "name"
+  ]
 }

--- a/src/static/jsedit/course-of-action.json
+++ b/src/static/jsedit/course-of-action.json
@@ -1,89 +1,38 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "course-of-action",
-    "description": "A Course of Action is an action taken either to prevent an attack or to respond to an attack that is in progress. ",
-    "type": "object",
-    "$ref": "static/jsedit/core.json",
-    "properties": {
-        "id": {
-            "type": "string",
-            "title": "id",
-            "pattern": "^course-of-action--",
-            "default": "course-of-action--",
-            "readonly": "true"
-        },
+  "$id": "http://raw.githubusercontent.com/oasis-open/cti-stix2-json-schemas/stix2.1/schemas/sdos/course-of-action.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "course-of-action",
+  "description": "A Course of Action is an action taken either to prevent an attack or to respond to an attack that is in progress. ",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "static/jsedit/core.json"
+    },
+    {
+      "properties": {
         "type": {
-            "type": "string",
-            "description": "The type of this object, which MUST be the literal `course-of-action`.",
-            "default": "course-of-action",
-            "readonly": "true"
+          "type": "string",
+          "description": "The type of this object, which MUST be the literal `course-of-action`.",
+          "enum": [
+            "course-of-action"
+          ]
+        },
+        "id": {
+          "title": "id",
+          "pattern": "^course-of-action--"
         },
         "name": {
-            "type": "string",
-            "description": "The name used to identify the Course of Action."
+          "type": "string",
+          "description": "The name used to identify the Course of Action."
         },
         "description": {
-            "type": "string",
-            "format": "textarea",
-            "description": "A description that provides more details and context about this object, potentially including its purpose and its key characteristics."
-        },
-        "action_type": {
-            "type": "string",
-            "description": "The type of action that is included in either the action_bin property or the dereferenced content from the action_reference property. This is an open vocabulary and values SHOULD come from the course-of-action-type-ov.",
-            "$ref": "#/definitions/course-of-action-type-ov"
-        },
-        "os_execution_envs": {
-            "type": "array",
-            "description": "A recommendation on the operating system(s) that this course of action can be applied to.",
-            "items": {
-                "type": "string"
-            },
-            "minItems": 1
-        },
-        "action_reference": {
-            "type": "object",
-            "description": "The value of this property MUST be a valid external reference that resolves to the action content as defined by the action_type property.",
-            "properties": {
-                "source_name": {
-                    "type": "string",
-                    "description": "The source within which the external-reference is defined (system, registry, organization, etc.)"
-                },
-                "external_id": {
-                    "type": "string",
-                    "description": "An identifier for the external reference content."
-                },
-                "url": {
-                    "type": "string",
-                    "title": "url",
-                    "pattern": "^(?:(?:https?|ftp)://)(?:\\S+(?::\\S*)?@)?(?:(?!(?:10|127)(?:\\.\\d{1,3}){3})(?!(?:169\\.254|192\\.168)(?:\\.\\d{1,3}){2})(?!172\\.(?:1[6-9]|2\\d|3[0-1])(?:\\.\\d{1,3}){2})(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])(?:\\.(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}(?:\\.(?:[1-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\\.(?:[a-z\u00a1-\uffff]{2,}))\\.?)(?::\\d{2,5})?(?:[/?#]\\S*)?$",
-                    "description": "Matches the elements of a URL using a regular expression. Uses Diego Perini's regex from https://gist.github.com/dperini/729294."
-                },
-                "description": {
-                    "type": "string",
-                    "description": "A human readable description"
-                }
-            }
-        },
-        "action_bin": {
-            "type": "string",
-            "media": {
-            "binaryEncoding": "base64"
-            },
-            "description": "This property contains the base64 encoded 'commands' that represent the action for this Course of Action."
+          "type": "string",
+          "description": "A description that provides more details and context about this object, potentially including its purpose and its key characteristics."
         }
-    },
-    "required": [
-        "name"
-    ],
-    "definitions": {
-        "course-of-action-type-ov": {
-            "type": "string",
-            "enum": [
-                "textual:text/plain",
-                "textual:text/html",
-                "textual:text/md",
-                "textual:pdf"
-            ]
-        }
+      }
     }
+  ],
+  "required": [
+    "name"
+  ]
 }

--- a/src/static/jsedit/grouping.json
+++ b/src/static/jsedit/grouping.json
@@ -1,36 +1,37 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "grouping",
-    "description": "A Grouping object explicitly asserts that the referenced STIX Objects have a shared content.",
-    "type": "object",
-    "$ref": "static/jsedit/core.json",
-    "properties": {
-        "id": {
-            "title": "id",
-            "pattern": "^grouping--",
-            "default": "grouping--",
-            "type": "string",
-            "readonly": "true"
-        },
+  "$id": "http://raw.githubusercontent.com/oasis-open/cti-stix2-json-schemas/stix2.1/schemas/sdos/grouping.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "grouping",
+  "description": "A Grouping object explicitly asserts that the referenced STIX Objects have a shared content.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "static/jsedit/core.json"
+    },
+    {
+      "properties": {
         "type": {
           "type": "string",
           "description": "The type of this object, which MUST be the literal `grouping`.",
-          "default": "grouping",
-          "readonly": "true"
-      },
+          "enum": [
+            "grouping"
+          ]
+        },
+        "id": {
+          "title": "id",
+          "pattern": "^grouping--"
+        },
         "name": {
           "type": "string",
           "description": "A name used to identify the Grouping."
         },
         "description": {
           "type": "string",
-          "format": "textarea",
           "description": "A description which provides more details and context about the Grouping, potentially including the purpose and key characteristics."
         },
         "context": {
           "type": "string",
-          "description": "A short description of the particular context shared by the content referenced by the Grouping.",
-          "$ref": "#/definitions/grouping-context-ov"
+          "description": "A short description of the particular context shared by the content referenced by the Grouping."
         },
         "object_refs": {
           "type": "array",
@@ -40,19 +41,21 @@
           },
           "minItems": 1
         }
-    },
-    "required": [
-        "context",
-        "object_refs"
-    ],
-    "definitions": {
-        "grouping-context-ov": {
-          "type": "string",
-          "enum": [
-            "suspicious-activity",
-            "malware-analysis",
-            "unspecified"
-          ]
-        }
+      }
     }
+  ],
+  "required": [
+    "context",
+    "object_refs"
+  ],
+  "definitions": {
+    "grouping-context-ov": {
+      "type": "string",
+      "enum": [
+        "suspicious-activity",
+        "malware-analysis",
+        "unspecified"
+      ]
+    }
+  }
 }

--- a/src/static/jsedit/grouping.json
+++ b/src/static/jsedit/grouping.json
@@ -31,7 +31,8 @@
         },
         "context": {
           "type": "string",
-          "description": "A short description of the particular context shared by the content referenced by the Grouping."
+          "description": "A short description of the particular context shared by the content referenced by the Grouping.",
+          "$ref": "#/definitions/grouping-context-ov"
         },
         "object_refs": {
           "type": "array",

--- a/src/static/jsedit/identity.json
+++ b/src/static/jsedit/identity.json
@@ -39,13 +39,15 @@
         },
         "identity_class": {
           "type": "string",
-          "description": "The type of entity that this Identity describes, e.g., an individual or organization. Open Vocab - identity-class-ov"
+          "description": "The type of entity that this Identity describes, e.g., an individual or organization. Open Vocab - identity-class-ov",
+          "$ref": "#/definitions/identity-class-ov"
         },
         "sectors": {
           "type": "array",
           "description": "The list of sectors that this Identity belongs to. Open Vocab - industry-sector-ov",
           "items": {
-            "type": "string"
+            "type": "string",
+            "$ref": "#/definitions/industry-sector-ov"
           },
           "minItems": 1
         },

--- a/src/static/jsedit/identity.json
+++ b/src/static/jsedit/identity.json
@@ -1,108 +1,115 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "identity",
-    "description": "Identities can represent actual individuals, organizations, or groups (e.g., ACME, Inc.) as well as classes of individuals, organizations, or groups.",
-    "type": "object",
-    "$ref": "static/jsedit/core.json",
-    "properties": {
+  "$id": "http://raw.githubusercontent.com/oasis-open/cti-stix2-json-schemas/stix2.1/schemas/sdos/identity.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "identity",
+  "description": "Identities can represent actual individuals, organizations, or groups (e.g., ACME, Inc.) as well as classes of individuals, organizations, or groups.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "static/jsedit/core.json"
+    },
+    {
+      "properties": {
         "type": {
-            "type": "string",
-            "description": "The type of this object, which MUST be the literal `identity`.",
-            "default": "identity",
-            "readonly": "true"
+          "type": "string",
+          "description": "The type of this object, which MUST be the literal `identity`.",
+          "enum": [
+            "identity"
+          ]
         },
         "id": {
-            "type": "string",
-            "title": "id",
-            "pattern": "^identity--",
-            "default": "identity--",
-            "readonly": "true"
-        },
-        "name": {
-            "type": "string",
-            "description": "The name of this Identity."
-        },
-        "description": {
-            "type": "string",
-            "format": "textarea",
-            "description": "A description that provides more details and context about the Identity."
+          "title": "id",
+          "pattern": "^identity--"
         },
         "roles": {
-            "type": "array",
-            "description": "The list of roles that this Identity performs (e.g., CEO, Domain Administrators, Doctors, Hospital, or Retailer). No open vocabulary is yet defined for this property.",
-            "items": {
-                "type": "string"
-            },
-            "minItems": 1
+          "type": "array",
+          "description": "The list of roles that this Identity performs (e.g., CEO, Domain Administrators, Doctors, Hospital, or Retailer). No open vocabulary is yet defined for this property.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of this Identity."
+        },
+        "description": {
+          "type": "string",
+          "description": "A description that provides more details and context about the Identity."
         },
         "identity_class": {
-            "title": "identity_class",
-            "description": "The type of entity that this Identity describes, e.g., an individual or organization. Open Vocab - identity-class-ov",
-            "type": "string",
-            "$ref": "#/definitions/identity-class-ov"
+          "type": "string",
+          "description": "The type of entity that this Identity describes, e.g., an individual or organization. Open Vocab - identity-class-ov"
         },
         "sectors": {
-            "type": "array",
-            "description": "The list of sectors that this Identity belongs to. Open Vocab - industry-sector-ov",
-            "items": {
-                "type": "string",
-                "$ref": "#/definitions/industry-sector-ov"
-            },
-            "minItems": 1
+          "type": "array",
+          "description": "The list of sectors that this Identity belongs to. Open Vocab - industry-sector-ov",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
         },
         "contact_information": {
-            "type": "string",
-            "description": "The contact information (e-mail, phone number, etc.) for this Identity."
+          "type": "string",
+          "description": "The contact information (e-mail, phone number, etc.) for this Identity."
         }
-    },
-    "required": [
-        "name",
-        "identity_class"
-
-    ],
-    "definitions": {
-        "identity-class-ov": {
-            "type": "string",
-            "enum": [
-                "individual",
-                "group",
-                "organization",
-                "class",
-                "unknown"
-            ]
-        },
-        "industry-sector-ov": {
-            "type": "string",
-            "enum": [
-                "agriculture",
-                "aerospace",
-                "automotive",
-                "communications",
-                "construction",
-                "defence",
-                "education",
-                "energy",
-                "engineering",
-                "entertainment",
-                "financial-services",
-                "government-national",
-                "government-regional",
-                "government-local",
-                "government-public-services",
-                "healthcare",
-                "hospitality-leisure",
-                "infrastructure",
-                "insurance",
-                "manufacturing",
-                "mining",
-                "non-profit",
-                "pharmaceuticals",
-                "retail",
-                "technology",
-                "telecommunications",
-                "transportation",
-                "utilities"
-            ]
-        }
+      }
     }
+  ],
+  "required": [
+    "name"
+  ],
+  "definitions": {
+    "identity-class-ov": {
+      "type": "string",
+      "enum": [
+        "individual",
+        "group",
+        "system",
+        "organization",
+        "class",
+        "unknown"
+      ]
+    },
+    "industry-sector-ov": {
+      "type": "string",
+      "enum": [
+        "agriculture",
+        "aerospace",
+        "automotive",
+        "chemical",
+        "commercial",
+        "communications",
+        "construction",
+        "defense",
+        "education",
+        "energy",
+        "engineering",
+        "entertainment",
+        "financial-services",
+        "government",
+        "emergency-services",
+        "government-local",
+        "government-national",
+        "government-public-services",
+        "government-regional",
+        "healthcare",
+        "hospitality-leisure",
+        "infrastructure",
+        "dams",
+        "nuclear",
+        "water",
+        "insurance",
+        "manufacturing",
+        "mining",
+        "non-profit",
+        "pharmaceuticals",
+        "retail",
+        "technology",
+        "telecommunications",
+        "transportation",
+        "utilities"
+      ]
+    }
+  }
 }

--- a/src/static/jsedit/incident.json
+++ b/src/static/jsedit/incident.json
@@ -1,0 +1,38 @@
+{
+  "$id": "http://raw.githubusercontent.com/oasis-open/cti-stix2-json-schemas/stix2.1/schemas/sdos/incident.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "incident",
+  "description": "The Incident object in STIX 2.1 is a stub, to be expanded in future STIX 2 releases.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "static/jsedit/core.json"
+    },
+    {
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The type of this object, which MUST be the literal `incident`.",
+          "enum": [
+            "incident"
+          ]
+        },
+        "id": {
+          "title": "id",
+          "pattern": "^incident--"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name used to identify the Incident."
+        },
+        "description": {
+          "type": "string",
+          "description": "A description that provides more details and context about the Incident."
+        }
+      }
+    }
+  ],
+  "required": [
+    "name"
+  ]
+}

--- a/src/static/jsedit/indicator.json
+++ b/src/static/jsedit/indicator.json
@@ -1,101 +1,101 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "indicator",
-    "description": "Indicators contain a pattern that can be used to detect suspicious or malicious cyber activity.",
-    "type": "object",
-    "$ref": "static/jsedit/core.json",
-    "properties": {
-        "id": {
-            "type": "string",
-            "title": "id",
-            "pattern": "^indicator--",
-            "default": "indicator--",
-            "readonly": "true"
-        },
+  "$id": "http://raw.githubusercontent.com/oasis-open/cti-stix2-json-schemas/stix2.1/schemas/sdos/indicator.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "indicator",
+  "description": "Indicators contain a pattern that can be used to detect suspicious or malicious cyber activity.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "static/jsedit/core.json"
+    },
+    {
+      "properties": {
         "type": {
-            "type": "string",
-            "description": "The type of this object, which MUST be the literal `indicator`.",
-            "default": "indicator",
-            "readonly": "true"
+          "type": "string",
+          "description": "The type of this object, which MUST be the literal `indicator`.",
+          "enum": [
+            "indicator"
+          ]
         },
-        "name": {
-            "type": "string",
-            "description": "The name used to identify the Indicator."
-        },
-        "description": {
-            "type": "string",
-            "format": "textarea",
-            "description": "A description that provides the recipient with context about this Indicator potentially including its purpose and its key characteristics.",
-            "format": "textarea"
+        "id": {
+          "title": "id",
+          "pattern": "^indicator--"
         },
         "indicator_types": {
-            "type": "array",
-            "description": "The values for this property SHOULD come from the indicator-type-ov open vocabulary.",
-            "items": {
-                "type": "string",
-                "$ref": "#/definitions/indicator-type-ov"
-            },
-            "minItems": 1
+          "type": "array",
+          "description": "This field is an Open Vocabulary that specifies the type of indicator. Open vocab - indicator-type-ov",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
+        },
+        "name": {
+          "type": "string",
+          "description": "The name used to identify the Indicator."
+        },
+        "description": {
+          "type": "string",
+          "description": "A description that provides the recipient with context about this Indicator potentially including its purpose and its key characteristics."
         },
         "pattern": {
-            "type": "string",
-            "description": "The detection pattern for this Indicator MAY be expressed as a STIX Pattern as specified in section 9 or another appropriate language such as SNORT, YARA, etc.",
-            "format": "textarea"
+          "type": "string",
+          "description": "The detection pattern for this indicator."
         },
-        "pattern_type": {
-            "type": "string",
-            "description": "The value for this property SHOULD come from the pattern-type-ov open vocabulary.",
-            "$ref": "#/definitions/pattern-type-ov"
+        "pattern_type" : {
+          "type" : "string",
+          "description": "The type of pattern used in this indicator."
         },
-        "pattern_version": {
-            "type": "string",
-            "description": "The version of the pattern language that is used for the data in the pattern property which MUST match the type of pattern data included in the pattern property."
+        "pattern_version" : {
+          "type" : "string",
+          "description": "The version of the pattern that is used."
         },
         "valid_from": {
-            "type": "string",
-            "format": "datetime",
-            "description": "The time from which this indicator should be considered valuable intelligence."
+          "$ref": "static/jsedit/common/timestamp.json",
+          "description": "The time from which this indicator should be considered valuable intelligence."
         },
         "valid_until": {
-            "type": "string",
-            "format": "datetime",
-            "description": "The time at which this indicator should no longer be considered valuable intelligence."
+          "$ref": "static/jsedit/common/timestamp.json",
+          "description": "The time at which this indicator should no longer be considered valuable intelligence."
         },
         "kill_chain_phases": {
-            "type": "array",
-            "description": "The list of kill chain phases for which this indicator is used.",
-            "$ref": "static/jsedit/kill-chain-phase.json",
-            "minItems": 1
+          "type": "array",
+          "description": "The phases of the kill chain that this indicator detects.",
+          "items": {
+            "$ref": "static/jsedit/common/kill-chain-phase.json"
+          },
+          "minItems": 1
         }
-    },
-    "required": [
-        "pattern",
-        "pattern_type",
-        "valid_from"
-    ],
-    "definitions": {
-        "indicator-type-ov": {
-            "type": "string",
-            "enum": [
-                "anomalous-activity",
-                "anonymization",
-                "benign",
-                "compromised",
-                "malicious-activity",
-                "attribution",
-                "unknown"
-            ]
-        },
-        "pattern-type-ov": {
-            "type": "string",
-            "enum": [
-                "stix",
-                "pcre",
-                "sigma",
-                "snort",
-                "suricata",
-                "yara"
-            ]
-        }
+      }
     }
+  ],
+  "required": [
+    "pattern",
+    "pattern_type",
+    "valid_from"
+  ],
+  "definitions": {
+    "indicator-type-ov": {
+      "type": "string",
+      "enum": [
+        "anomalous-activity",
+        "anonymization",
+        "benign",
+        "compromised",
+        "malicious-activity",
+        "attribution",
+        "unknown"
+      ]
+    },
+    "pattern-type-ov": {
+      "type": "string",
+      "enum": [
+        "stix",
+        "pcre",
+        "sigma",
+        "snort",
+        "suricata",
+        "yara"
+      ]
+    }
+  }
 }

--- a/src/static/jsedit/indicator.json
+++ b/src/static/jsedit/indicator.json
@@ -53,10 +53,12 @@
           "description": "The version of the pattern that is used."
         },
         "valid_from": {
+          "title":"valid_from",
           "$ref": "static/jsedit/common/timestamp.json",
           "description": "The time from which this indicator should be considered valuable intelligence."
         },
         "valid_until": {
+          "title":"valid_until",
           "$ref": "static/jsedit/common/timestamp.json",
           "description": "The time at which this indicator should no longer be considered valuable intelligence."
         },

--- a/src/static/jsedit/indicator.json
+++ b/src/static/jsedit/indicator.json
@@ -25,7 +25,8 @@
           "type": "array",
           "description": "This field is an Open Vocabulary that specifies the type of indicator. Open vocab - indicator-type-ov",
           "items": {
-            "type": "string"
+            "type": "string",
+            "$ref": "#/definitions/indicator-type-ov"
           },
           "minItems": 1
         },
@@ -43,7 +44,9 @@
         },
         "pattern_type" : {
           "type" : "string",
-          "description": "The type of pattern used in this indicator."
+          "description": "The type of pattern used in this indicator.", 
+          "$ref": "#/definitions/pattern-type-ov"
+
         },
         "pattern_version" : {
           "type" : "string",

--- a/src/static/jsedit/infrastructure.json
+++ b/src/static/jsedit/infrastructure.json
@@ -56,10 +56,12 @@
           "minItems": 1
         },
         "first_seen": {
+          "title":"first_seen",
           "$ref": "static/jsedit/common/timestamp.json",
           "description": "The time that this infrastructure was first seen performing malicious activities."
         },
         "last_seen": {
+          "title":"last_seen",
           "$ref": "static/jsedit/common/timestamp.json",
           "description": "The time that this infrastructure was last seen performing malicious activities."
         }

--- a/src/static/jsedit/infrastructure.json
+++ b/src/static/jsedit/infrastructure.json
@@ -1,87 +1,88 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "infrastructure",
-    "description": "Infrastructure objects describe systems, software services, and associated physical or virtual resources.",
-    "type": "object",
-    "$ref": "static/jsedit/core.json",
-    "properties": {
-        "id": {
-            "title": "id",
-            "type": "string",
-            "default": "infrastructure--",
-            "pattern": "^infrastructure--",
-            "readonly": "true"
-        },
+  "$id": "http://raw.githubusercontent.com/oasis-open/cti-stix2-json-schemas/stix2.1/schemas/sdos/infrastructure.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "infrastructure",
+  "description": "Infrastructure objects describe systems, software services, and associated physical or virtual resources.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "static/jsedit/core.json"
+    },
+    {
+      "properties": {
         "type": {
           "type": "string",
           "description": "The type of this object, which MUST be the literal `infrastructure`.",
-          "default": "infrastructure",
-          "readonly": "true"
+          "enum": [
+            "infrastructure"
+          ]
+        },
+        "id": {
+          "title": "id",
+          "pattern": "^infrastructure--"
         },
         "name": {
-            "type": "string",
-            "description": "The name used to identify the Infrastructure."
+          "type": "string",
+          "description": "The name used to identify the Infrastructure."
         },
         "description": {
-            "type": "string",
-            "format": "textarea",
-            "description": "A description that provides more details and context about this Infrastructure potentially including its purpose and its key characteristics."
+          "type": "string",
+          "description": "A description that provides more details and context about this Infrastructure potentially including its purpose and its key characteristics."
         },
         "infrastructure_types": {
-            "type": "array",
-            "description": "This field is an Open Vocabulary that specifies the type of infrastructure. Open vocab - infrastructure-type-ov",
-            "items": {
-                "type": "string",
-                "$ref": "#/definitions/infrastructure-type-ov"
-            },
-            "minItems": 1
+          "type": "array",
+          "description": "This field is an Open Vocabulary that specifies the type of infrastructure. Open vocab - infrastructure-type-ov",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
         },
         "aliases": {
-            "type": "array",
-            "description": "Alternative names used to identify this Infrastructure.",
-            "items": {
-                "type": "string"
-            },
-            "minItems": 1
+          "type": "array",
+          "description": "Alternative names used to identify this Infrastructure.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
         },
         "kill_chain_phases": {
-            "type": "array",
-            "description": "The list of kill chain phases for which this infrastructure is used.",
-            "$ref": "static/jsedit/kill-chain-phase.json",
-            "minItems": 1
+          "type": "array",
+          "description": "The list of kill chain phases for which this infrastructure is used.",
+          "items": {
+            "$ref": "static/jsedit/common/kill-chain-phase.json"
+          },
+          "minItems": 1
         },
         "first_seen": {
-            "$ref": "static/jsedit/common/timestamp.json",
-            "description": "The time that this infrastructure was first seen performing malicious activities."
+          "$ref": "static/jsedit/common/timestamp.json",
+          "description": "The time that this infrastructure was first seen performing malicious activities."
         },
-            "last_seen": {
-                "$ref": "static/jsedit/common/timestamp.json",
-                "description": "The time that this infrastructure was last seen performing malicious activities."
+        "last_seen": {
+          "$ref": "static/jsedit/common/timestamp.json",
+          "description": "The time that this infrastructure was last seen performing malicious activities."
         }
-    },
-    "required": [
-        "id"
-    ],
-    "definitions": {
-        "infrastructure-type-ov": {
-            "type": "string",
-            "enum": [
-                "amplification",
-                "anonymization",
-                "botnet",
-                "command-and-control",
-                "control-system",
-                "exfiltration",
-                "firewall",
-                "hosting-malware",
-                "hosting-target-lists",
-                "phishing",
-                "reconnaissance",
-                "routers-switches",
-                "staging",
-                "workstation",
-                "unknown"
-            ]
-        }
+      }
     }
+  ],
+  "required": [
+    "name"
+  ],
+  "definitions": {
+    "infrastructure-type-ov": {
+      "type": "string",
+      "enum": [
+        "amplification",
+        "anonymization",
+        "botnet",
+        "command-and-control",
+        "exfiltration",
+        "hosting-malware",
+        "hosting-target-lists",
+        "phishing",
+        "reconnaissance",
+        "staging",
+        "unknown"
+      ]
+    }
+  }
 }

--- a/src/static/jsedit/infrastructure.json
+++ b/src/static/jsedit/infrastructure.json
@@ -33,7 +33,9 @@
           "type": "array",
           "description": "This field is an Open Vocabulary that specifies the type of infrastructure. Open vocab - infrastructure-type-ov",
           "items": {
-            "type": "string"
+            "type": "string", 
+            "$ref": "#/definitions/infrastructure-type-ov"
+            
           },
           "minItems": 1
         },

--- a/src/static/jsedit/intrusion-set.json
+++ b/src/static/jsedit/intrusion-set.json
@@ -55,17 +55,20 @@
         },
         "resource_level": {
           "type": "string",
-          "description": "This defines the organizational level at which this Intrusion Set typically works. Open Vocab - attack-resource-level-ov"
+          "description": "This defines the organizational level at which this Intrusion Set typically works. Open Vocab - attack-resource-level-ov",
+          "$ref": "#/definitions/attack-resource-level-ov"
         },
         "primary_motivation": {
           "type": "string",
-          "description": "The primary reason, motivation, or purpose behind this Intrusion Set. Open Vocab - attack-motivation-ov"
+          "description": "The primary reason, motivation, or purpose behind this Intrusion Set. Open Vocab - attack-motivation-ov",
+          "$ref": "#/definitions/attack-motivation-ov"
         },
         "secondary_motivations": {
           "type": "array",
           "description": "The secondary reasons, motivations, or purposes behind this Intrusion Set. Open Vocab - attack-motivation-ov",
           "items": {
-            "type": "string"
+            "type": "string",
+            "$ref": "#/definitions/attack-motivation-ov"
           },
           "minItems": 1
         }

--- a/src/static/jsedit/intrusion-set.json
+++ b/src/static/jsedit/intrusion-set.json
@@ -1,107 +1,106 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "intrusion-set",
-    "description": "An Intrusion Set is a grouped set of adversary behavior and resources with common properties that is believed to be orchestrated by a single organization.",
-    "type": "object",
-    "$ref": "static/jsedit/core.json",
-    "properties": {
-        "id": {
-            "type": "string",
-            "title": "id",
-            "pattern": "^intrusion-set--",
-            "default": "intrusion-set--",
-            "readonly": "true"
-        },
+  "$id": "http://raw.githubusercontent.com/oasis-open/cti-stix2-json-schemas/stix2.1/schemas/sdos/intrusion-set.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "intrusion-set",
+  "description": "An Intrusion Set is a grouped set of adversary behavior and resources with common properties that is believed to be orchestrated by a single organization.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "static/jsedit/core.json"
+    },
+    {
+      "properties": {
         "type": {
-            "type": "string",
-            "description": "The type of this object, which MUST be the literal `intrusion-set`.",
-            "default": "intrusion-set",
-            "readonly": "true"
+          "type": "string",
+          "description": "The type of this object, which MUST be the literal `intrusion-set`.",
+          "enum": [
+            "intrusion-set"
+          ]
+        },
+        "id": {
+          "title": "id",
+          "pattern": "^intrusion-set--"
         },
         "name": {
-            "type": "string",
-            "description": "The name used to identify the Intrusion Set."
+          "type": "string",
+          "description": "The name used to identify the Intrusion Set."
         },
         "description": {
-            "type": "string",
-            "format": "textarea",
-            "description": "Provides more context and details about the Intrusion Set object."
+          "type": "string",
+          "description": "Provides more context and details about the Intrusion Set object."
         },
         "aliases": {
-            "type": "array",
-            "description": "Alternative names used to identify this Intrusion Set.",
-            "items": {
-                "type": "string"
-            },
-            "minItems": 1
+          "type": "array",
+          "description": "Alternative names used to identify this Intrusion Set.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
         },
         "first_seen": {
-            "type": "string",
-            "format": "datetime-local"
+          "$ref": "static/jsedit/common/timestamp.json",
+          "description": "The time that this Intrusion Set was first seen."
         },
         "last_seen": {
-            "type": "string",
-            "format": "datetime-local"
+          "$ref": "static/jsedit/common/timestamp.json",
+          "description": "The time that this Intrusion Set was last seen."
         },
         "goals": {
-            "type": "array",
-            "title": "goals",
-            "description": "The high level goals of this Intrusion Set, namely, what are they trying to do.",
-            "items": {
-                "type": "string",
-                "$ref": "#/definitions/attack-motivation-ov"
-            },
-            "minItems": 1
+          "type": "array",
+          "description": "The high level goals of this Intrusion Set, namely, what are they trying to do.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
         },
         "resource_level": {
-            "type": "string",
-            "description": "This defines the organizational level at which this Intrusion Set typically works. Open Vocab - attack-resource-level-ov",
-            "$ref": "#/definitions/attack-resource-level-ov"
+          "type": "string",
+          "description": "This defines the organizational level at which this Intrusion Set typically works. Open Vocab - attack-resource-level-ov"
         },
         "primary_motivation": {
-            "type": "string",
-            "description": "The primary reason, motivation, or purpose behind this Intrusion Set. Open Vocab - attack-motivation-ov",
-            "$ref": "#/definitions/attack-motivation-ov"
+          "type": "string",
+          "description": "The primary reason, motivation, or purpose behind this Intrusion Set. Open Vocab - attack-motivation-ov"
         },
         "secondary_motivations": {
-            "type": "array",
-            "description": "The secondary reasons, motivations, or purposes behind this Intrusion Set. Open Vocab - attack-motivation-ov",
-            "items": {
-                "type": "string",
-                "$ref": "#/definitions/attack-motivation-ov"
-            },
-            "minItems": 1
+          "type": "array",
+          "description": "The secondary reasons, motivations, or purposes behind this Intrusion Set. Open Vocab - attack-motivation-ov",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
         }
-    },
-    "required": [
-        "name"
-    ],
-    "definitions": {
-        "attack-resource-level-ov": {
-            "type": "string",
-            "enum": [
-                "individual",
-                "club",
-                "contest",
-                "team",
-                "organization",
-                "government"
-            ]
-        },
-        "attack-motivation-ov": {
-            "type": "string",
-            "enum": [
-                "accidental",
-                "coercion",
-                "dominance",
-                "ideology",
-                "notoriety",
-                "organizational-gain",
-                "personal-gain",
-                "personal-satisfaction",
-                "revenge",
-                "unpredictable"
-            ]
-        }
+      }
     }
+  ],
+  "required": [
+    "name"
+  ],
+  "definitions": {
+    "attack-resource-level-ov": {
+      "type": "string",
+      "enum": [
+        "individual",
+        "club",
+        "contest",
+        "team",
+        "organization",
+        "government"
+      ]
+    },
+    "attack-motivation-ov": {
+      "type": "string",
+      "enum": [
+        "accidental",
+        "coercion",
+        "dominance",
+        "ideology",
+        "notoriety",
+        "organizational-gain",
+        "personal-gain",
+        "personal-satisfaction",
+        "revenge",
+        "unpredictable"
+      ]
+    }
+  }
 }

--- a/src/static/jsedit/intrusion-set.json
+++ b/src/static/jsedit/intrusion-set.json
@@ -38,10 +38,12 @@
           "minItems": 1
         },
         "first_seen": {
+          "title":"first_seen",
           "$ref": "static/jsedit/common/timestamp.json",
           "description": "The time that this Intrusion Set was first seen."
         },
         "last_seen": {
+          "title":"last_seen",
           "$ref": "static/jsedit/common/timestamp.json",
           "description": "The time that this Intrusion Set was last seen."
         },

--- a/src/static/jsedit/language-content.json
+++ b/src/static/jsedit/language-content.json
@@ -1,49 +1,58 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://raw.githubusercontent.com/oasis-open/cti-stix2-json-schemas/stix2.1/schemas/common/language-content.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "language-content",
     "description": "The language-content object represents text content for STIX Objects represented in languages other than that of the original object.",
     "type": "object",
-    "properties": {
-        "id": {
-            "title": "id",
-            "pattern": "^language-content--",
-            "type": "string",
-            "default": "language-content--",
-            "readonly": "true"
-        },
-        "type": {
+    "allOf": [
+      {
+        "$ref": "static/jsedit/core.json"
+      },
+      {
+        "properties": {
+          "type": {
             "type": "string",
             "description": "The type of this object, which MUST be the literal `language-content`.",
-            "default": "language-content",
-            "readonly": "true"
-        },
-        "object_ref": {
+            "enum": [
+              "language-content"
+            ]
+          },
+          "id": {
+            "title": "id",
+            "pattern": "^language-content--"
+          },
+          "object_ref": {
             "title": "object_ref",
             "description": "Identifies the object that this Language Content applies to.",
             "allOf": [
-                {
-                    "$ref": "static/jsedit/common/identifier.json"
-                },
-                {
-                    "not": {
-                        "pattern": "^(bundle|language-content)--.+$"
-                    }
+              {
+                "$ref": "static/jsedit/common/identifier.json"
+              },
+              {
+                "not": {
+                  "pattern": "^(bundle|language-content)--.+$"
                 }
+              }
             ]
-        },
-        "object_modified": {
+          },
+          "object_modified": {
             "title": "object_modified",
             "$ref": "static/jsedit/common/timestamp.json",
             "description": "Identifies the modified time of the object that this Language Content applies to."
-        },
-        "contents": {
+          },
+          "contents": {
             "title": "contents",
             "$ref": "static/jsedit/common/dictionary.json",
             "description": "Contains the actual Language Content (translation)."
+          }
         }
-    },
-    "required": [
-        "object_ref",
-        "contents"
+      },
+      {
+        "required": [
+          "object_ref",
+          "contents"
+        ]
+      }
     ]
-}
+  }
+  

--- a/src/static/jsedit/location.json
+++ b/src/static/jsedit/location.json
@@ -47,7 +47,8 @@
         },
         "region": {
           "type": "string",
-          "description": "The region that this Location describes."
+          "description": "The region that this Location describes.",
+          "$ref": "#/definitions/region-ov"
         },
 
         "country": {

--- a/src/static/jsedit/location.json
+++ b/src/static/jsedit/location.json
@@ -1,109 +1,109 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "location",
-    "description": "A Location represents a geographic location.",
-    "type": "object",
-    "$ref": "static/jsedit/core.json",
-    "properties": {
-        "id": {
-            "title": "id",
-            "pattern": "^location--",
-            "type": "string",
-            "default": "location--",
-            "readonly": "true"
-        },
+  "$id": "http://raw.githubusercontent.com/oasis-open/cti-stix2-json-schemas/stix2.1/schemas/sdos/location.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "location",
+  "description": "A Location represents a geographic location. The location may be described as any, some or all of the following: region (e.g., North America), civic address (e.g. New York, US), latitude and longitude.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "static/jsedit/core.json"
+    },
+    {
+      "properties": {
         "type": {
           "type": "string",
           "description": "The type of this object, which MUST be the literal `location`.",
-          "default": "location",
-          "readonly": "true"
-      },
+          "enum": [
+            "location"
+          ]
+        },
+        "id": {
+          "title": "id",
+          "pattern": "^location--"
+        },
+        "description": {
+          "type": "string",
+          "description": "A textual description of the Location."
+        },
         "name" : {
           "type" : "string",
           "description": "A name used to identify the Location."
-         },
-        "description": {
-         "type": "string",
-         "description": "A textual description of the Location."
-       },
-       "latitude": {
-         "type": "number",
-         "description": "The latitude of the Location in decimal degrees.",
-         "minimum": -90,
-         "maximum": 90
-       },
-       "longitude": {
-         "type": "number",
-         "description": "The longitude of the Location in decimal degrees.",
-         "minimum": -180,
-         "maximum": 180
-       },
-       "precision": {
-         "type": "number",
-         "description": "Defines the precision of the coordinates specified by the latitude and longitude properties, measured in meters."
-       },
-       "region": {
-         "type": "string",
-         "description": "The region that this Location describes. This property SHOULD contain a value from region-ov.",
-         "$ref": "#/definitions/region-ov"
-       },
-       "country": {
-         "type": "string",
-         "description": "The country that this Location describes."
-       },
-       "administrative_area": {
-         "type": "string",
-         "description": "The state, province, or other sub-national administrative area that this Location describes."
-       },
-       "city": {
-         "type": "string",
-         "description": "The city that this Location describes."
-       },
-       "street_address": {
-         "type": "string",
-         "description": "The street address that this Location describes."
-       },
-       "postal_code": {
-         "type": "string",
-         "description": "The postal code for this Location."
-       }
-    },
-    "required": [
-    
-    ],
-    "definitions": {
-        "region-ov": {
-            "type": "string",
-            "enum": [
-                "africa",
-                "eastern-africa",
-                "middle-africa",
-                "northern-africa",
-                "southern-africa",
-                "western-africa",
-                "americas",
-                "latin-america-caribbean",
-                "south-america",
-                "caribbean",
-                "central-america",
-                "northern-america",
-                "asia",
-                "central-asia",
-                "eastern-asia",
-                "southern-asia",
-                "western-asia",
-                "europe",
-                "eastern-europe",
-                "northern-europe",
-                "southern-europe",
-                "western-europe",
-                "oceania",
-                "australia-new-zealand",
-                "melanesia",
-                "micronesia",
-                "polynesia",
-                "antarctica"
-            ]
+        },
+        "latitude": {
+          "type": "number",
+          "description": "The latitude of the Location in decimal degrees.",
+          "minimum": -90,
+          "maximum": 90
+        },
+        "longitude": {
+          "type": "number",
+          "description": "The longitude of the Location in decimal degrees.",
+          "minimum": -180,
+          "maximum": 180
+        },
+        "precision": {
+          "type": "number",
+          "description": "Defines the precision of the coordinates specified by the latitude and longitude properties, measured in meters."
+        },
+        "region": {
+          "type": "string",
+          "description": "The region that this Location describes."
+        },
+
+        "country": {
+          "type": "string",
+          "description": "The country that this Location describes."
+        },
+        "administrative_area": {
+          "type": "string",
+          "description": "The state, province, or other sub-national administrative area that this Location describes."
+        },
+        "city": {
+          "type": "string",
+          "description": "The city that this Location describes."
+        },
+        "street_address": {
+          "type": "string",
+          "description": "The street address that this Location describes."
+        },
+        "postal_code": {
+          "type": "string",
+          "description": "The postal code for this Location."
         }
+      }
     }
+  ],
+  "definitions": {
+    "region-ov": {
+      "type": "string",
+      "enum": [
+        "africa",
+        "eastern-africa",
+        "middle-africa",
+        "northern-africa",
+        "southern-africa",
+        "western-africa",
+        "americas",
+        "latin-america-caribbean",
+        "south-america",
+        "caribbean",
+        "central-america northern-america",
+        "asia",
+        "central-asia",
+        "eastern-asia",
+        "southern-asia",
+        "western-asia",
+        "europe eastern-europe",
+        "northern-europe",
+        "southern-europe",
+        "western-europe",
+        "oceania",
+        "australia-new-zealand",
+        "melanesia",
+        "micronesia",
+        "polynesia",
+        "antarctica"
+      ]
+    }
+  }
 }

--- a/src/static/jsedit/malware-analysis.json
+++ b/src/static/jsedit/malware-analysis.json
@@ -1,135 +1,156 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "malware-analysis",
-    "description": "Malware Analysis captures the metadata and results of a particular analysis performed (static or dynamic) on the malware instance or family.",
-    "type": "object",
-    "$ref": "static/jsedit/core.json",
-    "properties": {
-        "id": {
-            "title": "id",
-            "pattern": "^malware-analysis--",
-            "type": "string",
-            "default": "malware-analysis--",
-            "readonly": "true"
-        },
+  "$id": "http://raw.githubusercontent.com/oasis-open/cti-stix2-json-schemas/stix2.1/schemas/sdos/malware-analysis.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "malware-analysis",
+  "description": "Malware Analysis captures the metadata and results of a particular analysis performed (static or dynamic) on the malware instance or family.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "static/jsedit/core.json"
+    },
+    {
+      "properties": {
         "type": {
-            "type": "string",
-            "description": "The type of this object, which MUST be the literal `malware-analysis`.",
-            "default": "malware-analysis",
-            "readonly": "true"
+          "type": "string",
+          "description": "The type of this object, which MUST be the literal `malware-analysis`.",
+          "enum": [
+            "malware-analysis"
+          ]
+        },
+        "id": {
+          "title": "id",
+          "pattern": "^malware-analysis--"
         },
         "product": {
-            "type": "string",
-            "description": "The name of the analysis engine or product that was used for this analysis."
+          "type": "string",
+          "description": "The name of the analysis engine or product that was used for this analysis."
         },
         "version": {
-            "type": "string",
-            "description": "The version of the analysis product that was used to perform this analysis."
-        },
-        "host_vm_ref": {
-            "description": "A description of the virtual machine environment used to host the guest operating system (if applicable) that was used for the dynamic analysis of the malware instance or family.",
-            "allOf": [
-                {
-                    "$ref": "static/jsedit/common/identifier.json"
-                },
-                {
-                    "pattern": "^software--"
-                }
-            ]
-        },
-        "operating_system_ref": {
-            "description": "The operating system that was used to perform the dynamic analysis.",
-            "allOf": [
-                {
-                    "$ref": "static/jsedit/common/identifier.json"
-                },
-                {
-                    "pattern": "^software--"
-                }
-            ]
-        },
-        "installed_software_refs": {
-            "type": "array",
-            "description": "Any non-standard software installed on the operating system used for the dynamic analysis of the malware instance or family.",
-            "items": {
-                "allOf": [
-                    {
-                        "$ref": "static/jsedit/common/identifier.json"
-                    },
-                    {
-                        "pattern": "^software--"
-                    }
-                ]
-            },
-            "minItems": 1
+          "type": "string",
+          "description": "The version of the analysis product that was used to perform this analysis."
         },
         "configuration_version": {
-            "type": "string",
-            "description": "The version of the analysis product configuration that was used to perform this analysis."
+          "type": "string",
+          "description": "The version of the analysis product configuration that was used to perform this analysis."
         },
         "modules": {
-            "type" : "array",
-            "items": {
-                "type": "string"
-            },
-            "description": "The particular analysis product modules that were used to perform the analysis.",
-            "minItems": 1
+          "type" : "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The particular analysis product modules that were used to perform the analysis.",
+          "minItems": 1
         },
         "analysis_engine_version": {
-            "type": "string",
-            "description": "The version of the analysis engine or product that was used to perform this analysis."
+          "type": "string",
+          "description": "The version of the analysis engine or product that was used to perform this analysis."
         },
         "analysis_definition_version": {
-            "type": "string",
-            "description": "The version of the analysis definitions used by the analysis tool."
+          "type": "string",
+          "description": "The version of the analysis definitions used by the analysis tool."
         },
         "submitted": {
-            "$ref": "static/jsedit/common/timestamp.json",
-            "description": "The date and time that this malware was first submitted for scanning or analysis."
+          "$ref": "static/jsedit/common/timestamp.json",
+          "description": "The date and time that this malware was first submitted for scanning or analysis."
         },
         "analysis_started": {
-            "$ref": "static/jsedit/common/timestamp.json",
-            "description": "The date and time that the malware analysis was initiated."
+          "$ref": "static/jsedit/common/timestamp.json",
+          "description": "The date and time that the malware analysis was initiated."
         },
         "analysis_ended": {
-            "$ref": "static/jsedit/common/timestamp.json",
-            "description": "The date and time that the malware analysis ended."
+          "$ref": "static/jsedit/common/timestamp.json",
+          "description": "The date and time that the malware analysis ended."
         },
         "result_name": {
-            "type": "string",
-            "description": "The classification result or name assigned to the malware instance by the scanner tool."
+          "type": "string",
+          "description": "The classification result or name assigned to the malware instance by the scanner tool."
         },
         "result": {
-            "type": "string",
-            "description": "The classification result as determined by the scanner or tool analysis process.",
-            "$ref": "#/definitions/malware-result-ov"
+          "type": "string",
+          "description": "The classification result as determined by the scanner or tool analysis process.",
+          "$ref": "#/definitions/malware-av-result-ov"
+        },
+        "host_vm_ref": {
+          "description": "A description of the virtual machine environment used to host the guest operating system (if applicable) that was used for the dynamic analysis of the malware instance or family.",
+          "allOf": [
+            {
+              "$ref": "static/jsedit/common/identifier.json"
+            },
+            {
+              "pattern": "^software--"
+            }
+          ]
+        },
+        "operating_system_ref": {
+          "description": "The operating system that was used to perform the dynamic analysis.",
+          "allOf": [
+            {
+              "$ref": "static/jsedit/common/identifier.json"
+            },
+            {
+              "pattern": "^software--"
+            }
+          ]
+        },
+        "installed_software_refs": {
+          "type": "array",
+          "description": "Any non-standard software installed on the operating system used for the dynamic analysis of the malware instance or family.",
+          "items": {
+            "allOf": [
+              {
+                "$ref": "static/jsedit/common/identifier.json"
+              },
+              {
+                "pattern": "^software--"
+              }
+            ]
+          },
+          "minItems": 1
         },
         "analysis_sco_refs": {
-            "type": "array",
-            "description": "The list of STIX objects that were captured during the analysis process.",
-            "items": {
-                "$ref": "static/jsedit/common/identifier.json"
-            },
-            "minItems": 1
+          "type": "array",
+          "description": "The list of STIX objects that were captured during the analysis process.",
+          "items": {
+            "$ref": "static/jsedit/common/identifier.json"
+          },
+          "minItems": 1
         },
         "sample_ref": {
-            "type": "string",
-            "description": "This property contains the reference to the SCO file, network traffic or artifact object that this malware analysis was performed against.",
-            "$ref": "static/jsedit/common/identifier.json"
+          "description": "Refers to the object this analysis was performed against.",
+          "allOf": [
+            {
+              "$ref": "static/jsedit/common/identifier.json"
+            },
+            {
+              "oneOf": [
+                {
+                  "pattern": "^artifact--"
+                },
+                {
+                  "pattern": "^file--"
+                },
+                {
+                  "pattern": "^network-traffic--"
+                }
+              ]
+            }
+          ]
         }
-    },
-    "required": [
-        "product"
-    ],
-    "definitions": {
-        "malware-result-ov": {
-            "type": "string",
-            "enum": [
-                "malicious",
-                "suspicious",
-                "benign",
-                "unknown"
-            ]
-        }
+      }
     }
+  ],
+  "required": [
+    "product"
+  ],
+  "definitions": {
+    "malware-av-result-ov": {
+      "type": "string",
+      "enum": [
+        "malicious",
+        "suspicious",
+        "benign",
+        "unknown"
+      ]
+    }
+  }
 }

--- a/src/static/jsedit/malware-analysis.json
+++ b/src/static/jsedit/malware-analysis.json
@@ -50,14 +50,17 @@
           "description": "The version of the analysis definitions used by the analysis tool."
         },
         "submitted": {
+          "title":"submitted",
           "$ref": "static/jsedit/common/timestamp.json",
           "description": "The date and time that this malware was first submitted for scanning or analysis."
         },
         "analysis_started": {
+          "title":"analysis_started",
           "$ref": "static/jsedit/common/timestamp.json",
           "description": "The date and time that the malware analysis was initiated."
         },
         "analysis_ended": {
+          "title":"analysis_ended",
           "$ref": "static/jsedit/common/timestamp.json",
           "description": "The date and time that the malware analysis ended."
         },
@@ -71,6 +74,7 @@
           "$ref": "#/definitions/malware-av-result-ov"
         },
         "host_vm_ref": {
+          "title": "host_vm_ref",
           "description": "A description of the virtual machine environment used to host the guest operating system (if applicable) that was used for the dynamic analysis of the malware instance or family.",
           "allOf": [
             {
@@ -82,6 +86,7 @@
           ]
         },
         "operating_system_ref": {
+          "title": "operating_system_ref",
           "description": "The operating system that was used to perform the dynamic analysis.",
           "allOf": [
             {
@@ -116,23 +121,14 @@
           "minItems": 1
         },
         "sample_ref": {
+          "title":"sample_ref",
           "description": "Refers to the object this analysis was performed against.",
           "allOf": [
             {
               "$ref": "static/jsedit/common/identifier.json"
             },
             {
-              "oneOf": [
-                {
-                  "pattern": "^artifact--"
-                },
-                {
-                  "pattern": "^file--"
-                },
-                {
-                  "pattern": "^network-traffic--"
-                }
-              ]
+              "pattern": "^(artifact--|file--|network-traffic--)"
             }
           ]
         }

--- a/src/static/jsedit/malware.json
+++ b/src/static/jsedit/malware.json
@@ -1,223 +1,227 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "malware",
-    "description": "Malware is a type of TTP that is also known as malicious code and malicious software, refers to a program that is inserted into a system, usually covertly, with the intent of compromising the confidentiality, integrity, or availability of the victim's data, applications, or operating system (OS) or of otherwise annoying or disrupting the victim.",
-    "type": "object",
-    "$ref": "static/jsedit/core.json",
-    "properties": {
-        "id": {
-            "type": "string",
-            "title": "id",
-            "pattern": "^malware--",
-            "default": "malware--",
-            "readonly": "true"
-        },
+  "$id": "http://raw.githubusercontent.com/oasis-open/cti-stix2-json-schemas/stix2.1/schemas/sdos/malware.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "malware",
+  "description": "Malware is a type of TTP that is also known as malicious code and malicious software, refers to a program that is inserted into a system, usually covertly, with the intent of compromising the confidentiality, integrity, or availability of the victim's data, applications, or operating system (OS) or of otherwise annoying or disrupting the victim.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "static/jsedit/core.json"
+    },
+    {
+      "properties": {
         "type": {
-            "type": "string",
-            "description": "The type of this object, which MUST be the literal `malware`.",
-            "default": "malware",
-            "readonly": "true"
+          "type": "string",
+          "description": "The type of this object, which MUST be the literal `malware`.",
+          "enum": [
+            "malware"
+          ]
         },
-        "name": {
-            "type": "string",
-            "description": "The name used to identify the Malware."
+        "id": {
+          "title": "id",
+          "pattern": "^malware--"
         },
-        "description": {
-            "type": "string",
-            "format": "textarea",
-            "description": "Provides more context and details about the Malware object."
+        "aliases" : {
+          "type" : "array",
+          "description": "Alternative names used to identify this Malware or Malware family.",
+          "items" : {
+            "type" : "string"
+          },
+          "minItems" : 1
+        },
+        "first_seen" : {
+          "$ref": "static/jsedit/common/timestamp.json",
+          "description": "The time that the malware instance or family was first seen."
+        },
+        "last_seen" : {
+          "$ref": "static/jsedit/common/timestamp.json",
+          "description": "The time that the malware family or malware instance was last seen."
+        },
+        "operating_system_refs" : {
+          "type" : "array",
+          "description": "The operating systems that the malware family or malware instance is executable on.",
+          "items" : {
+            "allOf": [
+              {
+                "$ref": "static/jsedit/common/identifier.json"
+              },
+              {
+                "pattern": "^software--"
+              }
+            ]
+          },
+          "minItems" : 1
+        },
+        "architecture_execution_envs" : {
+          "type" : "array",
+          "description": "The processor architectures (e.g., x86, ARM, etc.) that the malware instance or family is executable on. Open Vocab - processor-architecture-os.",
+          "items" : {
+            "type" : "string"
+          },
+          "minItems" : 1
+        },
+        "implementation_languages" : {
+          "type" : "array",
+          "description": "The programming language(s) used to implement the malware instance or family. Open Vocab - implementation-language-ov.",
+          "items" : {
+            "type" : "string"
+          },
+          "minItems" : 1
+        },
+        "capabilities" : {
+          "type" : "array",
+          "description": "Specifies any capabilities identified for the malware instance or family. Open Vocab - malware-capabilities-ov.",
+          "items" : {
+            "type" : "string"
+          },
+          "minItems" : 1
+        },
+        "sample_refs" : {
+          "type" : "array",
+          "description": "The sample_refs property specifies a list of identifiers of the SCO file or artifact objects associated with this malware instance(s) or family.",
+          "items" : {
+            "type" : "string"
+          },
+          "minItems" : 1
         },
         "malware_types": {
-            "type": "array",
-            "description": "The values for this property SHOULD come from the malware-type-ov open vocabulary.",
-            "items": {
-                "type": "string",
-                "$ref": "#/definitions/malware-type-ov"
-            },
-            "minItems": 1
+          "type": "array",
+          "description": "The type of malware being described. Open Vocab - malware-type-ov",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
         },
-        "is_family": {
-            "type": "boolean",
-            "description": "Whether the object represents a malware family (if true) or a malware instance (if false).",
-            "enum": [
-                false,
-                true
-            ]
+        "name": {
+          "type": "string",
+          "description": "The name used to identify the Malware."
         },
-        "aliases": {
-            "type": "array",
-            "description": "Alternative names used to identify this malware or malware family.",
-            "items": {
-                "type": "string"
-            },
-            "minItems": 1
+        "description": {
+          "type": "string",
+          "description": "Provides more context and details about the Malware object."
         },
         "kill_chain_phases": {
-            "type": "array",
-            "description": "The list of Kill Chain Phases for which this malware can be used.",
-            "$ref": "static/jsedit/kill-chain-phase.json",
-            "minItems": 1
-        },
-        "first_seen": {
-            "$ref": "static/jsedit/common/timestamp.json",
-            "description": "The time that the malware instance or family was first seen."
-        },
-        "last_seen": {
-            "$ref": "static/jsedit/common/timestamp.json",
-            "description": "The time that the malware family or malware instance was last seen."
-        },
-        "operating_system_refs": {
-            "type": "array",
-            "description": "The operating systems that the malware family or malware instance is executable on. This applies to virtualized operating systems as well as those running on bare metal. The value of this property MUST be the identifier for a SCO software object.",
-            "items": {
-                "$ref": "static/jsedit/common/identifier.json"
-            },
-            "minItems": 1
-        },
-        "architecture_execution_envs": {
-            "type": "array",
-            "description": "The processor architectures (e.g., x86, ARM, etc.) that the malware instance or family is executable on.",
-            "items": {
-                "$ref": "#/definitions/processor-architecture-ov"
-            },
-            "minItems": 1
-        },
-        "implementation_languages": {
-            "type": "array",
-            "description": "The programming language(s) used to implement the malware instance or family.",
-            "items": {
-                "$ref": "#/definitions/implementation-language-ov"
-            },
-            "minItems": 1
-        },
-        "capabilites": {
-            "type": "array",
-            "description": "Specifies any capabilities identified for the malware instance or family.",
-            "items": {
-                "$ref": "#/definitions/malware-capabilities-ov"
-            },
-            "minItems": 1
-        },
-        "sample_refs": {
-            "type": "array",
-            "description": "The sample_refs property specifies a list of identifiers of the SCO file or artifact objects associated with this malware instance(s) or family.",
-            "items": {
-                "$ref": "static/jsedit/common/identifier.json"
-            },
-            "minItems": 1
+          "type": "array",
+          "description": "The list of kill chain phases for which this Malware instance can be used.",
+          "items": {
+            "$ref": "static/jsedit/common/kill-chain-phase.json"
+          },
+          "minItems": 1
         }
-    },
-    "required": [
-        "is_family"
-    ],
-    "definitions": {
-        "malware-type-ov": {
-            "type": "string",
-            "enum": [
-                "adware",
-                "backdoor",
-                "bot",
-                "bootkit",
-                "ddos",
-                "downloader",
-                "dropper",
-                "exploit-kit",
-                "keylogger",
-                "ransomware",
-                "remote-access-trojan",
-                "resource-exploitation",
-                "rogue-security-software",
-                "rootkit",
-                "screen-capture",
-                "spyware",
-                "trojan",
-                "unknown",
-                "virus",
-                "webshell",
-                "wiper",
-                "worm"
-            ]
-        },
-        "implementation-language-ov": {
-            "type": "string",
-            "enum": [
-                "applescript",
-                "bash",
-                "c",
-                "c++",
-                "c#",
-                "go",
-                "java",
-                "javascript",
-                "lua",
-                "objective-c",
-                "perl",
-                "php",
-                "powershell",
-                "python",
-                "ruby",
-                "scala",
-                "swift",
-                "typescript",
-                "visual-basic",
-                "x86-32",
-                "x86-64"
-            ]
-        },
-        "malware-capabilities-ov": {
-            "type": "string",
-            "enum": [
-                "accesses-remote-machines",
-                "anti-debugging",
-                "anti-disassembly",
-                "anti-emulation",
-                "anti-memory-forensics",
-                "anti-sandbox",
-                "anti-vm",
-                "captures-input-peripherals",
-                "captures-output-peripherals",
-                "captures-system-state-data",
-                "cleans-traces-of-infection",
-                "commits-fraud",
-                "communicates-with-c2",
-                "compromises-data-availability",
-                "compromises-data-integrity",
-                "compromises-system-availability",
-                "controls-local-machine",
-                "degrades-security-software",
-                "degrades-system-updates",
-                "determines-c2-server",
-                "emails-spam",
-                "escalates-privileges",
-                "evades-av",
-                "exfiltrates-data",
-                "fingerprints-host",
-                "hides-artifacts",
-                "hides-executing-code",
-                "infects-files",
-                "infects-remote-machines",
-                "installs-other-components",
-                "persists-after-system-reboot",
-                "prevents-artifact-access",
-                "prevents-artifact-deletion",
-                "probes-network-environment",
-                "self-modifies",
-                "steals-authentication-credentials",
-                "violates-system-operational-integrity"
-            ]
-        },
-        "processor-architecture-ov": {
-            "type": "string",
-            "enum": [
-                "alpha",
-                "arm",
-                "ia-64",
-                "mips",
-                "powerpc",
-                "sparc",
-                "x86",
-                "x86-64"
-            ]
-        }
+      }
     }
+  ],
+  "required": [
+    "is_family"
+  ],
+  "definitions": {
+    "malware-type-ov": {
+      "type": "string",
+      "enum": [
+        "adware",
+        "backdoor",
+        "bot",
+        "bootkit",
+        "ddos",
+        "downloader",
+        "dropper",
+        "exploit-kit",
+        "keylogger",
+        "ransomware",
+        "remote-access-trojan",
+        "resource-exploitation",
+        "rogue-security-software",
+        "rootkit",
+        "screen-capture",
+        "spyware",
+        "trojan",
+        "unknown",
+        "virus",
+        "webshell",
+        "wiper",
+        "worm"
+      ]
+    },
+    "implementation-language-ov": {
+      "type": "string",
+      "enum": [
+        "applescript",
+        "bash",
+        "c",
+        "c++",
+        "c#",
+        "go",
+        "java",
+        "javascript",
+        "lua",
+        "objective-c",
+        "perl",
+        "php",
+        "powershell",
+        "python",
+        "ruby",
+        "scala",
+        "swift",
+        "typescript",
+        "visual-basic",
+        "x86-32",
+        "x86-64"
+      ]
+    },
+    "malware-capabilities-ov": {
+      "type": "string",
+      "enum": [
+        "accesses-remote-machines",
+        "anti-debugging",
+        "anti-disassembly",
+        "anti-emulation",
+        "anti-memory-forensics",
+        "anti-sandbox",
+        "anti-vm",
+        "captures-input-peripherals",
+        "captures-output-peripherals",
+        "captures-system-state-data",
+        "cleans-traces-of-infection",
+        "commits-fraud",
+        "communicates-with-c2",
+        "compromises-data-availability",
+        "compromises-data-integrity",
+        "compromises-system-availability",
+        "controls-local-machine",
+        "degrades-security-software",
+        "degrades-system-updates",
+        "determines-c2-server",
+        "emails-spam",
+        "escalates-privileges",
+        "evades-av",
+        "exfiltrates-data",
+        "fingerprints-host",
+        "hides-artifacts",
+        "hides-executing-code",
+        "infects-files",
+        "infects-remote-machines",
+        "installs-other-components",
+        "persists-after-system-reboot",
+        "prevents-artifact-access",
+        "prevents-artifact-deletion",
+        "probes-network-environment",
+        "self-modifies",
+        "steals-authentication-credentials",
+        "violates-system-operational-integrity"
+      ]
+    },
+    "processor-architecture-ov": {
+      "type": "string",
+      "enum": [
+        "alpha",
+        "arm",
+        "ia-64",
+        "mips",
+        "powerpc",
+        "sparc",
+        "x86",
+        "x86-64"
+      ]
+    }
+  }
 }

--- a/src/static/jsedit/malware.json
+++ b/src/static/jsedit/malware.json
@@ -56,7 +56,8 @@
           "type" : "array",
           "description": "The processor architectures (e.g., x86, ARM, etc.) that the malware instance or family is executable on. Open Vocab - processor-architecture-os.",
           "items" : {
-            "type" : "string"
+            "type" : "string",
+            "$ref":"#/definitions/processor-architecture-ov"
           },
           "minItems" : 1
         },
@@ -64,7 +65,8 @@
           "type" : "array",
           "description": "The programming language(s) used to implement the malware instance or family. Open Vocab - implementation-language-ov.",
           "items" : {
-            "type" : "string"
+            "type" : "string",
+            "$ref":"#/definitions/implementation-language-ov"
           },
           "minItems" : 1
         },
@@ -72,7 +74,8 @@
           "type" : "array",
           "description": "Specifies any capabilities identified for the malware instance or family. Open Vocab - malware-capabilities-ov.",
           "items" : {
-            "type" : "string"
+            "type" : "string",
+            "$ref":"#/definitions/malware-capabilities-ov"
           },
           "minItems" : 1
         },
@@ -88,7 +91,8 @@
           "type": "array",
           "description": "The type of malware being described. Open Vocab - malware-type-ov",
           "items": {
-            "type": "string"
+            "type": "string",
+            "$ref":"#/definitions/malware-type-ov"
           },
           "minItems": 1
         },

--- a/src/static/jsedit/malware.json
+++ b/src/static/jsedit/malware.json
@@ -30,10 +30,12 @@
           "minItems" : 1
         },
         "first_seen" : {
+          "title":"first_seen",
           "$ref": "static/jsedit/common/timestamp.json",
           "description": "The time that the malware instance or family was first seen."
         },
         "last_seen" : {
+          "title":"last_seen",
           "$ref": "static/jsedit/common/timestamp.json",
           "description": "The time that the malware family or malware instance was last seen."
         },

--- a/src/static/jsedit/note.json
+++ b/src/static/jsedit/note.json
@@ -1,54 +1,55 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "note",
-    "description": "A Note is a comment or note containing informative text to help explain the context of one or more STIX Objects (SDOs or SROs) or to provide additional analysis that is not contained in the original object.",
-    "type": "object",
-    "$ref": "static/jsedit/core.json",
-    "properties": {
-        "id": {
-            "title": "id",
-            "pattern": "^note--",
-            "default": "note--",
-            "type": "string",
-            "readonly": "true"
-        },
+  "$id": "http://raw.githubusercontent.com/oasis-open/cti-stix2-json-schemas/stix2.1/schemas/sdos/note.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "note",
+  "description": "A Note is a comment or note containing informative text to help explain the context of one or more STIX Objects (SDOs or SROs) or to provide additional analysis that is not contained in the original object.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "static/jsedit/core.json"
+    },
+    {
+      "properties": {
         "type": {
-            "type": "string",
-            "description": "The type of this object, which MUST be the literal `note`.",
-            "default": "note",
-            "readonly": "true"
+          "type": "string",
+          "description": "The type of this object, which MUST be the literal `note`.",
+          "enum": [
+            "note"
+          ]
         },
-        "name": {
-            "type": "string",
-            "description": "The name used to identify the note."
+        "id": {
+          "title": "id",
+          "pattern": "^note--"
         },
         "abstract": {
-            "type": "string",
-            "description": "A brief summary of the note."
+          "type": "string",
+          "description": "A brief summary of the note."
         },
         "content": {
-            "type": "string",
-            "description": "The content of the note."
+          "type": "string",
+          "description": "The content of the note."
         },
         "authors": {
-            "type": "array",
-            "description": "The name of the author(s) of this note (e.g., the analyst(s) that created it).",
-            "items": {
-                "type": "string"
-            },
-            "minItems": 1
+          "type": "array",
+          "description": "The name of the author(s) of this note (e.g., the analyst(s) that created it).",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
         },
         "object_refs": {
-            "type": "array",
-            "description": "The STIX Objects (SDOs and SROs) that the note is being applied to.",
-            "items": {
-                "$ref": "static/jsedit/common/identifier.json"
-            },
-            "minItems": 1
+          "type": "array",
+          "description": "The STIX Objects (SDOs and SROs) that the note is being applied to.",
+          "items": {
+            "$ref": "static/jsedit/common/identifier.json"
+          },
+          "minItems": 1
         }
-    },
-    "required": [
-        "object_refs",
-        "content"
-    ]
+      }
+    }
+  ],
+  "required": [
+    "content",
+    "object_refs"
+  ]
 }

--- a/src/static/jsedit/observed-data.json
+++ b/src/static/jsedit/observed-data.json
@@ -22,10 +22,12 @@
           "pattern": "^observed-data--"
         },
         "first_observed": {
+          "title": "first_observed",
           "$ref": "static/jsedit/common/timestamp.json",
           "description": "The beginning of the time window that the data was observed during."
         },
         "last_observed": {
+          "title": "last_observed",
           "$ref": "static/jsedit/common/timestamp.json",
           "description": "The end of the time window that the data was observed during."
         },

--- a/src/static/jsedit/observed-data.json
+++ b/src/static/jsedit/observed-data.json
@@ -1,132 +1,138 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "observed-data",
-    "description": "Observed data conveys information that was observed on systems and networks, such as log data or network traffic, using the Cyber Observable specification.",
-    "type": "object",
-    "$ref": "static/jsedit/core.json",
-    "properties": {
-        "id": {
-            "title": "id",
-            "pattern": "^observed-data--",
-            "type": "string",
-            "default": "observed-data--",
-            "readonly": "true"
-        },
+  "$id": "http://raw.githubusercontent.com/oasis-open/cti-stix2-json-schemas/stix2.1/schemas/sdos/observed-data.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "observed-data",
+  "description": "Observed data conveys information that was observed on systems and networks, such as log data or network traffic, using the Cyber Observable specification.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "static/jsedit/core.json"
+    },
+    {
+      "properties": {
         "type": {
-            "type": "string",
-            "description": "The type of this object, which MUST be the literal `observed-data`.",
-            "default": "observed-data",
-            "readonly": "true"
+          "type": "string",
+          "description": "The type of this object, which MUST be the literal `observed-data`.",
+          "enum": [
+            "observed-data"
+          ]
+        },
+        "id": {
+          "title": "id",
+          "pattern": "^observed-data--"
         },
         "first_observed": {
-            "type": "string",
-            "description": "The beginning of the time window that the data was observed during."
+          "$ref": "static/jsedit/common/timestamp.json",
+          "description": "The beginning of the time window that the data was observed during."
         },
         "last_observed": {
-            "type": "string",
-            "description": "The end of the time window that the data was observed during."
+          "$ref": "static/jsedit/common/timestamp.json",
+          "description": "The end of the time window that the data was observed during."
         },
         "number_observed": {
-            "type": "integer",
-            "description": "The number of times the data represented in the objects property was observed. This MUST be an integer between 1 and 999,999,999 inclusive.",
-            "minimum": 1,
-            "maximum": 999999999,
-            "default": 1
-        },
-        "object_refs": {
-            "type": "array",
-            "description": "A list of id's referencing SCOs and SROs representing the observation. The object_refs MUST contain at least one SCO reference if defined.",
-            "items": {
-              "$ref": "static/jsedit/common/identifier.json"
-            },
-            "minItems": 1
+          "type": "integer",
+          "description": "The number of times the data represented in the objects property was observed. This MUST be an integer between 1 and 999,999,999 inclusive.",
+          "minimum": 1,
+          "maximum": 999999999
         },
         "objects": {
-            "type": "object",
-            "description": "A dictionary of Cyber Observable Objects that describes the single 'fact' that was observed.",
-            "minProperties": 1,
-            "patternProperties": {
-                "^.*$": {
-                    "type": "object",
-                    "oneOf": [{
-                            "allOf": [{
-                                    "$ref": "static/jsedit/common/cyber-observable-core.json"
-                                },
-                                {
-                                    "not": {
-                                        "properties": {
-                                            "type": {
-                                                "type": "string",
-                                                "pattern": "^artifact|directory|file|mutex|process|software|user-account|windows-registry-key|x509-certificate|autonomous-system|domain-name|email-addr|email-message|ipv4-addr|ipv6-addr|mac-addr|network-traffic|url$",
-                                                "description": "Indicates that this object is a custom Observable Object."
-                                            }
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "$ref": "static/jsedit/observables/artifact.json"
-                        },
-                        {
-                            "$ref": "static/jsedit/observables/autonomous-system.json"
-                        },
-                        {
-                            "$ref": "static/jsedit/observables/directory.json"
-                        },
-                        {
-                            "$ref": "static/jsedit/observables/domain-name.json"
-                        },
-                        {
-                            "$ref": "static/jsedit/observables/email-addr.json"
-                        },
-                        {
-                            "$ref": "static/jsedit/observables/email-message.json"
-                        },
-                        {
-                            "$ref": "static/jsedit/observables/file.json"
-                        },
-                        {
-                            "$ref": "static/jsedit/observables/ipv4-addr.json"
-                        },
-                        {
-                            "$ref": "static/jsedit/observables/ipv6-addr.json"
-                        },
-                        {
-                            "$ref": "static/jsedit/observables/mac-addr.json"
-                        },
-                        {
-                            "$ref": "static/jsedit/observables/mutex.json"
-                        },
-                        {
-                            "$ref": "static/jsedit/observables/network-traffic.json"
-                        },
-                        {
-                            "$ref": "static/jsedit/observables/process.json"
-                        },
-                        {
-                            "$ref": "static/jsedit/observables/software.json"
-                        },
-                        {
-                            "$ref": "static/jsedit/observables/url.json"
-                        },
-                        {
-                            "$ref": "static/jsedit/observables/user-account.json"
-                        },
-                        {
-                            "$ref": "static/jsedit/observables/windows-registry-key.json"
-                        },
-                        {
-                            "$ref": "static/jsedit/observables/x509-certificate.json"
+          "type": "object",
+          "description": "A dictionary of Cyber Observable Objects that describes the single 'fact' that was observed.",
+          "minProperties": 1,
+          "patternProperties": {
+            "^.*$": {
+              "type": "object",
+              "oneOf": [
+                {
+                  "allOf": [
+                    {
+                      "$ref": "static/jsedit/common/cyber-observable-core.json"
+                    },
+                    {
+                      "not": {
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "pattern": "^artifact|directory|file|mutex|process|software|user-account|windows-registry-key|x509-certificate|autonomous-system|domain-name|email-addr|email-message|ipv4-addr|ipv6-addr|mac-addr|network-traffic|url$",
+                            "description": "Indicates that this object is a custom Observable Object."
+                          }
                         }
-                    ]
+                      }
+                    }
+                  ]
+                },
+                {
+                  "$ref": "static/jsedit/observables/artifact.json"
+                },
+                {
+                  "$ref": "static/jsedit/observables/autonomous-system.json"
+                },
+                {
+                  "$ref": "static/jsedit/observables/directory.json"
+                },
+                {
+                  "$ref": "static/jsedit/observables/domain-name.json"
+                },
+                {
+                  "$ref": "static/jsedit/observables/email-addr.json"
+                },
+                {
+                  "$ref": "static/jsedit/observables/email-message.json"
+                },
+                {
+                  "$ref": "static/jsedit/observables/file.json"
+                },
+                {
+                  "$ref": "static/jsedit/observables/ipv4-addr.json"
+                },
+                {
+                  "$ref": "static/jsedit/observables/ipv6-addr.json"
+                },
+                {
+                  "$ref": "static/jsedit/observables/mac-addr.json"
+                },
+                {
+                  "$ref": "static/jsedit/observables/mutex.json"
+                },
+                {
+                  "$ref": "static/jsedit/observables/network-traffic.json"
+                },
+                {
+                  "$ref": "static/jsedit/observables/process.json"
+                },
+                {
+                  "$ref": "static/jsedit/observables/software.json"
+                },
+                {
+                  "$ref": "static/jsedit/observables/url.json"
+                },
+                {
+                  "$ref": "static/jsedit/observables/user-account.json"
+                },
+                {
+                  "$ref": "static/jsedit/observables/windows-registry-key.json"
+                },
+                {
+                  "$ref": "static/jsedit/observables/x509-certificate.json"
                 }
+              ]
             }
+          }
+        },
+        "object_refs": {
+          "type": "array",
+          "description": "A list of SCOs and SROs representing the observation.",
+          "items": {
+            "$ref": "static/jsedit/common/identifier.json"
+          },
+          "minItems": 1
         }
-    },
-    "required": [
-        "first_observed",
-        "last_observed",
-        "number_observed"
-    ]
+      }
+    }
+  ],
+  "required": [
+    "first_observed",
+    "last_observed",
+    "number_observed"
+  ]
 }

--- a/src/static/jsedit/opinion.json
+++ b/src/static/jsedit/opinion.json
@@ -1,57 +1,62 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "opinion",
-    "description": "An Opinion is an assessment of the correctness of the information in a STIX Object produced by a different entity and captures the level of agreement or disagreement using a fixed scale.",
-    "type": "object",
-    "$ref": "static/jsedit/core.json",
-    "properties": {
-        "id": {
-            "title": "id",
-            "pattern": "^opinion--",
-            "default": "opinion--",
-            "type": "string",
-            "readonly": "true"
-        },
+  "$id": "http://raw.githubusercontent.com/oasis-open/cti-stix2-json-schemas/stix2.1/schemas/sdos/opinion.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "opinion",
+  "description": "An Opinion is an assessment of the correctness of the information in a STIX Object produced by a different entity and captures the level of agreement or disagreement using a fixed scale.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "static/jsedit/core.json"
+    },
+    {
+      "properties": {
         "type": {
-            "type": "string",
-            "description": "The type of this object, which MUST be the literal `opinion`.",
-            "default": "opinion",
-            "readonly": "true"
+          "type": "string",
+          "description": "The type of this object, which MUST be the literal `opinion`.",
+          "enum": [
+            "opinion"
+          ]
+        },
+        "id": {
+          "title": "id",
+          "pattern": "^opinion--"
         },
         "explanation": {
-            "type": "string",
-            "description": "An explanation of why the producer has this Opinion."
+          "type": "string",
+          "description": "An explanation of why the producer has this Opinion."
         },
         "authors": {
-            "type": "array",
-            "description": "The name of the author(s) of this opinion (e.g., the analyst(s) that created it).",
-            "items": {
+          "type": "array",
+          "description": "The name of the author(s) of this opinion (e.g., the analyst(s) that created it).",
+          "items": {
             "type": "string"
-            },
-            "minItems": 1
-        },
-        "opinion": {
-            "type": "string",
-            "description": "The opinion that the producer has about about all of the STIX Object(s) listed in the object_refs property.",
-            "enum": [
-                "strongly-disagree",
-                "disagree",
-                "neutral",
-                "agree",
-                "strongly-agree"
-            ]
+          },
+          "minItems": 1
         },
         "object_refs": {
-            "type": "array",
-            "description": "The STIX Objects (SDOs and SROs) that the opinion is being applied to.",
-            "items": {
+          "type": "array",
+          "description": "The STIX Objects (SDOs and SROs) that the opinion is being applied to.",
+          "items": {
             "$ref": "static/jsedit/common/identifier.json"
-            },
-            "minItems": 1
+          },
+          "minItems": 1
+        },
+        "opinion": {
+          "type": "string",
+          "description": "The opinion that the producer has about about all of the STIX Object(s) listed in the object_refs property.",
+          "enum": [
+            "strongly-disagree",
+            "disagree",
+            "neutral",
+            "agree",
+            "strongly-agree"
+          ]
         }
-    },
-    "required": [
-        "object_refs",
-        "opinion"
-    ]
+      }
+    }
+  ],
+  "required": [
+    "object_refs",
+    "opinion"
+  ]
 }

--- a/src/static/jsedit/report.json
+++ b/src/static/jsedit/report.json
@@ -39,6 +39,7 @@
           "description": "A description that provides more details and context about Report."
         },
         "published": {
+          "title":"published",
           "$ref": "static/jsedit/common/timestamp.json",
           "description": "The date that this report object was officially published by the creator of this report."
         },

--- a/src/static/jsedit/report.json
+++ b/src/static/jsedit/report.json
@@ -25,7 +25,8 @@
           "type": "array",
           "description": "This field is an Open Vocabulary that specifies the primary subject of this report. The suggested values for this field are in report-type-ov.",
           "items": {
-            "type": "string"
+            "type": "string",
+            "$ref":"#/definitions/report-type-ov"
           },
           "minItems": 1
         },

--- a/src/static/jsedit/report.json
+++ b/src/static/jsedit/report.json
@@ -1,74 +1,77 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "report",
-    "description": "Reports are collections of threat intelligence focused on one or more topics, such as a description of a threat actor, malware, or attack technique, including context and related details.",
-    "type": "object",
-    "$ref": "static/jsedit/core.json",
-    "properties": {
-        "id": {
-            "title": "id",
-            "pattern": "^report--",
-            "type": "string",
-            "default": "report--",
-            "readonly": "true"
-        },
+  "$id": "http://raw.githubusercontent.com/oasis-open/cti-stix2-json-schemas/stix2.1/schemas/sdos/report.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "report",
+  "description": "Reports are collections of threat intelligence focused on one or more topics, such as a description of a threat actor, malware, or attack technique, including context and related details.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "static/jsedit/core.json"
+    },
+    {
+      "properties": {
         "type": {
-            "type": "string",
-            "description": "The type of this object, which MUST be the literal `report`.",
-            "default": "report",
-            "readonly": "true"
+          "type": "string",
+          "description": "The type of this object, which MUST be the literal `report`.",
+          "enum": [
+            "report"
+          ]
         },
-        "name": {
-            "type": "string",
-            "description": "The name used to identify the Report."
-        },
-        "description": {
-            "type": "string",
-            "format": "textarea",
-            "description": "A description that provides more details and context about Report."
+        "id": {
+          "title": "id",
+          "pattern": "^report--"
         },
         "report_types": {
-            "type": "array",
-            "description": "The values for this property SHOULD come from the report-type-ov open vocabulary.",
-            "items": {
-                "type": "string",
-                "$ref": "#/definitions/report-type-ov"
-            },
-            "minItems": 0
+          "type": "array",
+          "description": "This field is an Open Vocabulary that specifies the primary subject of this report. The suggested values for this field are in report-type-ov.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
+        },
+        "name": {
+          "type": "string",
+          "description": "The name used to identify the Report."
+        },
+        "description": {
+          "type": "string",
+          "description": "A description that provides more details and context about Report."
         },
         "published": {
-            "type": "string",
-            "description": "The date that this report object was officially published by the creator of this report."
+          "$ref": "static/jsedit/common/timestamp.json",
+          "description": "The date that this report object was officially published by the creator of this report."
         },
         "object_refs": {
-            "type": "array",
-            "description": "Specifies the STIX Objects that are referred to by this Report.",
-            "items": {
-                "$ref": "static/jsedit/common/identifier.json"
-            },
-            "minItems": 1
+          "type": "array",
+          "description": "Specifies the STIX Objects that are referred to by this Report.",
+          "items": {
+            "$ref": "static/jsedit/common/identifier.json"
+          },
+          "minItems": 1
         }
-    },
-    "required": [
-        "name",
-        "object_refs",
-        "published"
-    ],
-    "definitions": {
-        "report-type-ov": {
-            "type": "string",
-            "enum": [
-                "attack-pattern",
-                "campaign",
-                "identity",
-                "indicator",
-                "malware",
-                "observed-data",
-                "threat-actor",
-                "threat-report",
-                "tool",
-                "vulnerability"
-            ]
-        }
+      }
     }
+  ],
+  "required": [
+    "name",
+    "object_refs",
+    "published"
+  ],
+  "definitions": {
+    "report-type-ov": {
+      "type": "string",
+      "enum": [
+        "threat-report",
+        "attack-pattern",
+        "campaign",
+        "identity",
+        "indicator",
+        "malware",
+        "observed-data",
+        "threat-actor",
+        "tool",
+        "vulnerability"
+      ]
+    }
+  }
 }

--- a/src/static/jsedit/sighting.json
+++ b/src/static/jsedit/sighting.json
@@ -32,6 +32,7 @@
             "maximum": 999999999
         },
         "sighting_of_ref": {
+            "title":"sighting_of_ref",
             "$ref": "static/jsedit/common/identifier.json",
             "description": "An ID reference to the object that has been sighted."
         },

--- a/src/static/jsedit/threat-actor.json
+++ b/src/static/jsedit/threat-actor.json
@@ -64,10 +64,12 @@
           "minItems": 1
         },
         "first_seen" : {
+          "title":"first_seen",
           "$ref": "static/jsedit/common/timestamp.json",
           "description": "The time that this Threat Actor was first seen."
         },
         "last_seen" : {
+          "title":"last_seen",
           "$ref": "static/jsedit/common/timestamp.json",
           "description": "The time that this Threat Actor was last seen."
         },

--- a/src/static/jsedit/threat-actor.json
+++ b/src/static/jsedit/threat-actor.json
@@ -25,7 +25,8 @@
           "type": "array",
           "description": "This field specifies the type of threat actor. Open Vocab - threat-actor-type-ov",
           "items": {
-            "type": "string"
+            "type": "string",
+            "$ref":"#/definitions/threat-actor-type-ov"
           },
           "minItems": 1
         },
@@ -49,7 +50,8 @@
           "type": "array",
           "description": "This is a list of roles the Threat Actor plays. Open Vocab - threat-actor-role-ov",
           "items": {
-            "type": "string"
+            "type": "string",
+            "$ref":"#/definitions/threat-actor-role-ov"
           },
           "minItems": 1
         },
@@ -71,21 +73,26 @@
         },
         "sophistication": {
           "type": "string",
-          "description": "The skill, specific knowledge, special training, or expertise a Threat Actor must have to perform the attack. Open Vocab - threat-actor-sophistication-ov"
+          "description": "The skill, specific knowledge, special training, or expertise a Threat Actor must have to perform the attack. Open Vocab - threat-actor-sophistication-ov",
+          "$ref": "#/definitions/threat-actor-sophistication-ov"
         },
         "resource_level": {
           "type": "string",
-          "description": "This defines the organizational level at which this Threat Actor typically works. Open Vocab - attack-resource-level-ov"
+          "description": "This defines the organizational level at which this Threat Actor typically works. Open Vocab - attack-resource-level-ov",
+          "$ref": "#/definitions/attack-resource-level-ov"
         },
         "primary_motivation": {
           "type": "string",
-          "description": "The primary reason, motivation, or purpose behind this Threat Actor. Open Vocab - attack-motivation-ov"
+          "description": "The primary reason, motivation, or purpose behind this Threat Actor. Open Vocab - attack-motivation-ov",
+          "$ref": "#/definitions/attack-motivation-ov"
+
         },
         "secondary_motivations": {
           "type": "array",
           "description": "The secondary reasons, motivations, or purposes behind this Threat Actor. Open Vocab - attack-motivation-ov",
           "items": {
-            "type": "string"
+            "type": "string",
+            "$ref": "#/definitions/attack-motivation-ov"
           },
           "minItems": 1
         },
@@ -93,7 +100,8 @@
           "type": "array",
           "description": "The personal reasons, motivations, or purposes of the Threat Actor regardless of organizational goals. Open Vocab - attack-motivation-ov",
           "items": {
-            "type": "string"
+            "type": "string",
+            "$ref": "#/definitions/attack-motivation-ov"
           },
           "minItems": 1
         }

--- a/src/static/jsedit/threat-actor.json
+++ b/src/static/jsedit/threat-actor.json
@@ -1,181 +1,175 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "threat-actor",
-    "description": "Threat Actors are actual individuals, groups, or organizations believed to be operating with malicious intent.",
-    "type": "object",
-    "$ref": "static/jsedit/core.json",
-    "properties": {
-        "id": {
-            "title": "id",
-            "pattern": "^threat-actor--",
-            "type": "string",
-            "default": "threat-actor--",
-            "readonly": "true"
-        },
+  "$id": "http://raw.githubusercontent.com/oasis-open/cti-stix2-json-schemas/stix2.1/schemas/sdos/threat-actor.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "threat-actor",
+  "description": "Threat Actors are actual individuals, groups, or organizations believed to be operating with malicious intent.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "static/jsedit/core.json"
+    },
+    {
+      "properties": {
         "type": {
-            "type": "string",
-            "description": "The type of this object, which MUST be the literal `threat-actor`.",
-            "default": "threat-actor",
-            "readonly": "true"
+          "type": "string",
+          "description": "The type of this object, which MUST be the literal `threat-actor`.",
+          "enum": [
+            "threat-actor"
+          ]
         },
-        "name": {
-            "type": "string",
-            "description": "A name used to identify this Threat Actor or Threat Actor group."
-        },
-        "description": {
-            "type": "string",
-            "format": "textarea",
-            "description": "A description that provides more details and context about the Threat Actor."
+        "id": {
+          "title": "id",
+          "pattern": "^threat-actor--"
         },
         "threat_actor_types": {
-            "type": "array",
-            "description": "The type(s) of this threat actor. Open Vocab - threat-actor-type-ov.",
-            "items": {
-                "type": "string",
-                "$ref": "#/definitions/threat-actor-type-ov"
-            },
-            "minItems": 1,
-            "default": 0
+          "type": "array",
+          "description": "This field specifies the type of threat actor. Open Vocab - threat-actor-type-ov",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
+        },
+        "name": {
+          "type": "string",
+          "description": "A name used to identify this Threat Actor or Threat Actor group."
+        },
+        "description": {
+          "type": "string",
+          "description": "A description that provides more details and context about the Threat Actor."
         },
         "aliases": {
-            "type": "array",
-            "description": "A list of other names that this Threat Actor is believed to use.",
-            "items": {
-                "type": "string"
-            },
-            "minItems": 1
-        },
-        "first_seen": {
-            "type": "string",
-            "format": "datetime",
-            "description": "The time that this Threat Actor was first seen."
-        },
-        "last_seen": {
-            "type": "string",
-            "format": "datetime",
-            "description": "The time that this Threat Actor was last seen."
+          "type": "array",
+          "description": "A list of other names that this Threat Actor is believed to use.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
         },
         "roles": {
-            "type": "array",
-            "description": "This is a list of roles the Threat Actor plays. Open Vocab - threat-actor-role-ov",
-            "items": {
-                "type": "string",
-                "$ref": "#/definitions/threat-actor-role-ov"
-            },
-            "minItems": 1
+          "type": "array",
+          "description": "This is a list of roles the Threat Actor plays. Open Vocab - threat-actor-role-ov",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
         },
         "goals": {
-            "type": "array",
-            "description": "The high level goals of this Threat Actor, namely, what are they trying to do.",
-            "items": {
-                "type": "string"
-            },
-            "minItems": 1
+          "type": "array",
+          "description": "The high level goals of this Threat Actor, namely, what are they trying to do.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
+        },
+        "first_seen" : {
+          "$ref": "static/jsedit/common/timestamp.json",
+          "description": "The time that this Threat Actor was first seen."
+        },
+        "last_seen" : {
+          "$ref": "static/jsedit/common/timestamp.json",
+          "description": "The time that this Threat Actor was last seen."
         },
         "sophistication": {
-            "type": "string",
-            "description": "The skill, specific knowledge, special training, or expertise a Threat Actor must have to perform the attack. Open Vocab - threat-actor-sophistication-ov",
-            "$ref": "#/definitions/threat-actor-sophistication-ov"
+          "type": "string",
+          "description": "The skill, specific knowledge, special training, or expertise a Threat Actor must have to perform the attack. Open Vocab - threat-actor-sophistication-ov"
         },
         "resource_level": {
-            "type": "string",
-            "description": "This defines the organizational level at which this Threat Actor typically works. Open Vocab - attack-resource-level-ov",
-            "$ref": "#/definitions/attack-resource-level-ov"
+          "type": "string",
+          "description": "This defines the organizational level at which this Threat Actor typically works. Open Vocab - attack-resource-level-ov"
         },
         "primary_motivation": {
-            "type": "string",
-            "description": "The primary reason, motivation, or purpose behind this Threat Actor. Open Vocab - attack-motivation-ov",
-            "$ref": "#/definitions/attack-motivation-ov"
+          "type": "string",
+          "description": "The primary reason, motivation, or purpose behind this Threat Actor. Open Vocab - attack-motivation-ov"
         },
         "secondary_motivations": {
-            "type": "array",
-            "description": "The secondary reasons, motivations, or purposes behind this Threat Actor. Open Vocab - attack-motivation-ov",
-            "items": {
-                "type": "string",
-                "$ref": "#/definitions/attack-motivation-ov"
-            },
-            "minItems": 1
+          "type": "array",
+          "description": "The secondary reasons, motivations, or purposes behind this Threat Actor. Open Vocab - attack-motivation-ov",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
         },
         "personal_motivations": {
-            "type": "array",
-            "description": "The personal reasons, motivations, or purposes of the Threat Actor regardless of organizational goals. Open Vocab - attack-motivation-ov",
-            "items": {
-                "type": "string",
-                "$ref": "#/definitions/attack-motivation-ov"
-            },
-            "minItems": 1
+          "type": "array",
+          "description": "The personal reasons, motivations, or purposes of the Threat Actor regardless of organizational goals. Open Vocab - attack-motivation-ov",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
         }
-    },
-    "required": [
-        "name"
-    ],
-    "definitions": {
-        "threat-actor-role-ov": {
-            "type": "string",
-            "enum": [
-                "agent",
-                "director",
-                "independent",
-                "sponsor",
-                "infrastructure-operator",
-                "infrastructure-architect",
-                "malware-author"
-            ]
-        },
-        "threat-actor-sophistication-ov": {
-            "type": "string",
-            "enum": [
-                "none",
-                "minimal",
-                "intermediate",
-                "advanced",
-                "strategic",
-                "expert",
-                "innovator"
-            ]
-        },
-        "threat-actor-type-ov": {
-            "type": "string",
-            "enum": [
-                "activist",
-                "competitor",
-                "crime-syndicate",
-                "criminal",
-                "hacker",
-                "insider-accidental",
-                "insider-disgruntled",
-                "nation-state",
-                "sensationalist",
-                "spy",
-                "terrorist",
-                "unknown"
-            ]
-        },
-        "attack-resource-level-ov": {
-            "type": "string",
-            "enum": [
-                "individual",
-                "club",
-                "contest",
-                "team",
-                "organization",
-                "government"
-            ]
-        },
-        "attack-motivation-ov": {
-            "type": "string",
-            "enum": [
-                "accidental",
-                "coercion",
-                "dominance",
-                "ideology",
-                "notoriety",
-                "organizational-gain",
-                "personal-gain",
-                "personal-satisfaction",
-                "revenge",
-                "unpredictable"
-            ]
-        }
+      }
     }
+  ],
+  "required": [
+    "name"
+  ],
+  "definitions": {
+    "threat-actor-type-ov": {
+      "type": "string",
+      "enum": [
+        "activist",
+        "competitor",
+        "crime-syndicate",
+        "criminal",
+        "hacker",
+        "insider-accidental",
+        "insider-disgruntled",
+        "nation-state",
+        "sensationalist",
+        "spy",
+        "terrorist",
+        "unknown"
+      ]
+    },
+    "threat-actor-role-ov": {
+      "type": "string",
+      "enum": [
+        "agent",
+        "director",
+        "independent",
+        "sponsor",
+        "infrastructure-operator",
+        "infrastructure-architect",
+        "malware-author"
+      ]
+    },
+    "threat-actor-sophistication-ov": {
+      "type": "string",
+      "enum": [
+        "none",
+        "minimal",
+        "intermediate",
+        "advanced",
+        "strategic",
+        "expert",
+        "innovator"
+      ]
+    },
+    "attack-resource-level-ov": {
+      "type": "string",
+      "enum": [
+        "individual",
+        "club",
+        "contest",
+        "team",
+        "organization",
+        "government"
+      ]
+    },
+    "attack-motivation-ov": {
+      "type": "string",
+      "enum": [
+        "accidental",
+        "coercion",
+        "dominance",
+        "ideology",
+        "notoriety",
+        "organizational-gain",
+        "personal-gain",
+        "personal-satisfaction",
+        "revenge",
+        "unpredictable"
+      ]
+    }
+  }
 }

--- a/src/static/jsedit/tool.json
+++ b/src/static/jsedit/tool.json
@@ -1,89 +1,81 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "tool",
-    "description": "Tools are legitimate software that can be used by threat actors to perform attacks.",
-    "type": "object",
-    "$ref": "static/jsedit/core.json",
-    "properties": {
-        "id": {
-            "title": "id",
-            "pattern": "^tool--",
-            "type": "string",
-            "default": "tool--",
-            "readonly": "true"
-        },
+  "$id": "http://raw.githubusercontent.com/oasis-open/cti-stix2-json-schemas/stix2.1/schemas/sdos/tool.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "tool",
+  "description": "Tools are legitimate software that can be used by threat actors to perform attacks.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "static/jsedit/core.json"
+    },
+    {
+      "properties": {
         "type": {
-            "type": "string",
-            "description": "The type of this object, which MUST be the literal `tool`.",
-            "default": "tool",
-            "readonly": "true"
+          "type": "string",
+          "description": "The type of this object, which MUST be the literal `tool`.",
+          "enum": [
+            "tool"
+          ]
         },
-        "name": {
-            "type": "string",
-            "description": "The name used to identify the Tool."
+        "id": {
+          "title": "id",
+          "pattern": "^tool--"
         },
-        "description": {
-            "type": "string",
-            "format": "textarea",
-            "description": "Provides more context and details about the Tool object."
+        "aliases" : {
+          "type" : "array",
+          "description": "Alternative names used to identify this Tool.",
+          "items" : {
+            "type" : "string"
+          },
+          "minItems" : 1
         },
         "tool_types": {
-            "type": "array",
-            "description": "The values for this property SHOULD come from the tool-type-ov open vocabulary.",
-            "items": {
-                "type": "string",
-                "$ref": "#/definitions/tool-type-ov"
-            },
-            "minItems": 1
+          "type": "array",
+          "description": "The kind(s) of tool(s) being described. Open Vocab - tool-type-ov",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
+        },
+        "name": {
+          "type": "string",
+          "description": "The name used to identify the Tool."
+        },
+        "description": {
+          "type": "string",
+          "description": "Provides more context and details about the Tool object."
         },
         "tool_version": {
-            "type": "string",
-            "description": "The version identifier associated with the tool."
-        },
-        "aliases": {
-            "type": "array",
-            "description": "Alternative names used to identify this tool.",
-            "items": {
-                "type": "string"
-            },
-            "minItems": 1
+          "type": "string",
+          "description": "The version identifier associated with the tool."
         },
         "kill_chain_phases": {
-            "type": "array",
-            "description": "The list of kill chain phases for which this Tool instance can be used.",
-            "$ref": "static/jsedit/kill-chain-phase.json",
-            "minItems": 1
+          "type": "array",
+          "description": "The list of kill chain phases for which this Tool instance can be used.",
+          "items": {
+            "$ref": "static/jsedit/common/kill-chain-phase.json"
+          },
+          "minItems": 1
         }
-
-    },
-    "required": [
-        "name" 
-    ],
-    "definitions": {
-        "tool-type-ov": {
-            "type": "string",
-            "enum": [
-                "denial-of-service",
-                "exploitation",
-                "information-gathering",
-                "network-capture",
-                "credential-exploitation",
-                "remote-access",
-                "vulnerability-scanning",
-                "unknown"
-            ]
-        },
-        "tool-label-ov": {
-            "type": "string",
-            "enum": [
-                "denial-of-service",
-                "exploitation",
-                "information-gathering",
-                "network-capture",
-                "credential-exploitation",
-                "remote-access",
-                "vulnerability-scanning"
-            ]
-        }
+      }
     }
+  ],
+  "required": [
+    "name"
+  ],
+  "definitions": {
+    "tool-type-ov": {
+      "type": "string",
+      "enum": [
+        "denial-of-service",
+        "exploitation",
+        "information-gathering",
+        "network-capture",
+        "credential-exploitation",
+        "remote-access",
+        "vulnerability-scanning",
+        "unknown"
+      ]
+    }
+  }
 }

--- a/src/static/jsedit/tool.json
+++ b/src/static/jsedit/tool.json
@@ -33,7 +33,8 @@
           "type": "array",
           "description": "The kind(s) of tool(s) being described. Open Vocab - tool-type-ov",
           "items": {
-            "type": "string"
+            "type": "string",
+            "$ref":"#/definitions/tool-type-ov"
           },
           "minItems": 1
         },

--- a/src/static/jsedit/vulnerability.json
+++ b/src/static/jsedit/vulnerability.json
@@ -1,34 +1,38 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "vulnerability",
-    "description": "A Vulnerability is a mistake in software that can be directly used by a hacker to gain access to a system or network.",
-    "type": "object",
-    "$ref": "core.json",
-    "properties": {
+  "$id": "http://raw.githubusercontent.com/oasis-open/cti-stix2-json-schemas/stix2.1/schemas/sdos/vulnerability.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "vulnerability",
+  "description": "A Vulnerability is a mistake in software that can be directly used by a hacker to gain access to a system or network.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "static/jsedit/core.json"
+    },
+    {
+      "properties": {
         "type": {
-            "type": "string",
-            "description": "The type of this object, which MUST be the literal `vulnerability`.",
-            "default": "vulnerability",
-            "readonly": "true"
+          "type": "string",
+          "description": "The type of this object, which MUST be the literal `vulnerability`.",
+          "enum": [
+            "vulnerability"
+          ]
         },
         "id": {
-            "title": "id",
-            "pattern": "^vulnerability--",
-            "type": "string",
-            "default": "vulnerability--",
-            "readonly": "true"
+          "title": "id",
+          "pattern": "^vulnerability--"
         },
         "name": {
-            "type": "string",
-            "description": "The name used to identify the Vulnerability."
+          "type": "string",
+          "description": "The name used to identify the Vulnerability."
         },
         "description": {
-            "type": "string",
-            "format": "textarea",
-            "description": "A description that provides more details and context about the Vulnerability."
+          "type": "string",
+          "description": "A description that provides more details and context about the Vulnerability."
         }
-    },
-    "required": [
-        "name"
-    ]
+      }
+    }
+  ],
+  "required": [
+    "name"
+  ]
 }

--- a/src/ui/dbFunctions.ts
+++ b/src/ui/dbFunctions.ts
@@ -57,7 +57,18 @@ export async function commitBundle (bundle: BundleType): Promise<[Set<string>, S
 }
 
 export async function commit (nodes: StixObject[], edges: Relationship[]): Promise<[Set<string>, Set<string>]> {
-  if (!nodes.every(checkProps) || !edges.every(checkProps)) throw new Error('Invalid stix');
+  edges.forEach(e=>{
+    if (!e.target_ref && !e.source_ref && !e.relationship_type){
+      //NOTE: this means that it is a visual edge, which ought to be removed
+      edges = edges.filter(obj => {return obj !== e});
+    }
+  })
+  if (!nodes.every(checkProps)){
+    throw new Error('Invalid objects');
+  }
+  if (!edges.every(checkProps)){
+    throw new Error('Invalid relationships')
+  }
   const pair: [StixObject[], Relationship[]] = [nodes, edges];
   return wrapReturn(pair, () => [new Set(), new Set()], ([n, e]) => currentDB.updateDB(n, e));
 }

--- a/src/ui/dbFunctions.ts
+++ b/src/ui/dbFunctions.ts
@@ -110,6 +110,7 @@ function getAllProps (schemaObject: IJSONClassOptions) {
 export function checkProps (object: StixObject): boolean {
   const schemaObject = schema.classes.find(c => { return c.name === object.type; });
   if (typeof schemaObject !== 'object') {
+    console.error(`${schemaObject} is not equal to type 'object'`);
     return false;
   }
 
@@ -121,7 +122,7 @@ export function checkProps (object: StixObject): boolean {
     if (prop.name === 'id_') continue;
 
     if (object[prop.name] === undefined) {
-      // Return false to indicate that this object is invalid
+      console.error(`${prop.name} is undefined for:\n`, object);
       return false;
     }
   }

--- a/src/ui/ipc-render-handlers.ts
+++ b/src/ui/ipc-render-handlers.ts
@@ -28,8 +28,8 @@ function cycore2stix (o: SingularElementArgument) {
  * Takes each object from the graph and commits them to the database
  */
 export async function commit_all () {
-  const nodes = window.cycore.$('nodes');
-  const edges = window.cycore.$('edges');
+  let nodes = window.cycore.$('nodes');
+  let edges = window.cycore.$('edges');
   const stix_nodes: StixObject[] = nodes.map(cycore2stix).filter(s => s !== undefined);
   const stix_edges: Relationship[] = edges.map(cycore2stix).filter(s => s !== undefined);
 
@@ -38,6 +38,10 @@ export async function commit_all () {
 
   for (let i = 0; i < nodes.length; i++) {
     const ele = nodes[i];
+    if (ele.data('raw_data') == undefined){
+      nodes = nodes.filter(obj => {return obj !== ele});
+      continue;
+    }
     const { id } = ele.data('raw_data');
     if (cnodes.has(id)) {
       ele.data('saved', true);
@@ -47,6 +51,10 @@ export async function commit_all () {
   for (let i = 0; i < edges.length; i++) {
     const ele = edges[i];
     const { id } = ele.data('raw_data');
+    if (ele.data('raw_data') == undefined){
+      nodes = nodes.filter(obj => {return obj !== ele});
+      continue;
+    }
     if (cedges.has(id)) {
       ele.data('saved', true);
     }


### PR DESCRIPTION
## Changes:
- Filtered out "visual-edge" objects from cytoscape which prevented DB committing
- Filtered out null objects from cytoscape which prevented DB committing
- Updated schema.
  - Some SDOs weren't being committed to DB because the old schema would mark them as invalid due to missing required properties, even though the new schema no longer required those properties. Resolved.
  - Some SDOs were missing properties or had extraneous properties because of the disconnect between old and new schemas. Resolved.

## Known issues:
- Improper relationships can be made. there is no active validation. this is a pre-existing bug
- In open-vocab enum selection, only the first value will show up. Any others will be in the json, but won't show up in the gui. this is a pre-existing bug
- Some optional properties show up as default. They can be removed. This is a pre-existing bug
- The new schema contained some specifications that the STIG code could not parse, so some changes to [this schema](https://github.com/oasis-open/cti-stix2-json-schemas/tree/688248bf06355c83a052838051d2e1ac26d4f008) were made. The schema was changed in the following ways:

| object           | titles added for                                                                           | other changes for proper parsing                                                                               |
| ---------------- | ------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
| campaign         | first_seen, last_seen                                                                      |                                                                                                                |
| indicator        | valid_from, valid_until                                                                    |                                                                                                                |
| infrastructure   | first_seen, last_seen                                                                      |                                                                                                                |
| intrusion-set    | first_seen, last_seen                                                                      |                                                                                                                |
| language-content | contents, object_ref, object_modified                                                      |                                                                                                                |
| location         |                                                                                            | all conditionally required properties removed                                                                  |
| malware-analysis | submitted, analysis_started, analysis_ended, host_vm_ref, operating_system_ref, sample_ref | pattern of sample_ref was combined ; conditional requirement of either result or analysis_sco_refs was removed |
| malware          | first_seen, last_seen                                                                      | required property was reduced to just is_family, ignoring conditional requirement for name                     |
| observed-data    | first_observed, last_observed                                                              | conditional requirement of either objects or object_refs was removed                                           |
| report           | published                                                                                  |                                                                                                                |
| sighting*        | sighting_of_ref                                                                            |                                                                                                                |
| threat-actor     | first_seen, last_seen                                                                      |

\* sighting isn't actually included as an option in STIG, but was edited for the sake of compatibility

Closes #121 